### PR TITLE
(chore): Refactor runtime wiring, harden parser edges, and update RepoGPT docs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,6 +24,6 @@ jobs:
             ~/.cache/pre-commit
           key: ${{ runner.os }}-${{ matrix.python-version }}-${{ hashFiles('uv.lock') }}
       - run: |
-          uv sync
+          uv sync --extra dev --locked
           uv run pre-commit run --all-files
           uv run pytest -q

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,12 +14,16 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
+      - name: Setup uv
+        uses: astral-sh/setup-uv@v5
       - name: Cache deps
         uses: actions/cache@v4
         with:
-          path: ~/.cache/pip
-          key: ${{ runner.os }}-${{ matrix.python-version }}-${{ hashFiles('pyproject.toml') }}
+          path: |
+            ~/.cache/uv
+            ~/.cache/pre-commit
+          key: ${{ runner.os }}-${{ matrix.python-version }}-${{ hashFiles('uv.lock') }}
       - run: |
-          pip install -e ".[dev]"
-          pre-commit run --all-files
-          pytest
+          uv sync
+          uv run pre-commit run --all-files
+          uv run pytest -q

--- a/.gitignore
+++ b/.gitignore
@@ -156,3 +156,4 @@ test_files.txt
 tests_files.txt
 
 .uv_cache
+.codex

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,10 +1,4 @@
 repos:
-  # - repo: https://github.com/psf/black
-  #   rev: 24.3.0
-  #   hooks:
-  #     - id: black
-  #       exclude: 'tests/(data|fixtures)/'
-
   - repo: https://github.com/charliermarsh/ruff-pre-commit
     rev: v0.4.4
     hooks:

--- a/Makefile
+++ b/Makefile
@@ -1,13 +1,13 @@
 .PHONY: test lint type clean repogpt
 
 lint:
-	ruff check .
+	uv run ruff check .
 
 type:
-	mypy src tests
+	uv run mypy src tests
 
 test:
-	pytest -q
+	uv run pytest -q
 
 clean:
 	find . -type d -name __pycache__ -exec rm -rf {} +
@@ -15,4 +15,4 @@ clean:
 	find . -type f -name "*.pyc" -delete
 
 repogpt:
-	python -m repogpt.app.cli
+	uv run repogpt

--- a/README.md
+++ b/README.md
@@ -1,276 +1,219 @@
 # RepoGPT
 
-> **Abstraction, summarization and code intelligence — built for both humans and LLMs**
-> **Status:** RepoGPT already exposes a structured intermediate representation capable of supporting hierarchical and multi-granular retrieval. However, the RAG-oriented projection (`code-units`) flattens much of that hierarchy into plain code units, so the current benchmark mainly evaluates unit segmentation quality rather than true hierarchical retrieval behavior.
+RepoGPT turns a source tree into deterministic structural artifacts for humans, automation, and LLM-oriented tooling.
 
-RepoGPT turns a source-tree into a *consultable abstraction layer*:  
-structured, queryable and ready for downstream indexing or RAG pipelines.
+Primary public interfaces today:
 
+- CLI: `repogpt`
+- MCP stdio server: `repogpt-mcp`
+
+Runtime pipeline:
+
+```text
+[Collector] -> [Loader] -> [Parser] -> [Projector] -> [Writer]
+     |            |           |            |             |
+   paths      bytes/text   CodeNode IR   AST / code-units   file / stdout
 ```
 
-[Collector] → [Parser] → [Processor] → [Publisher]
-    |            |            |             |
-  paths    CodeNode-trees   optional     JSON / NDJSON / stdout
+Key properties:
 
-```
+- Supported languages in the current contract: Python (`.py`) and Markdown (`.md`)
+- Public artifact contracts: AST JSON/NDJSON (`schema_version: "1"`) and `code-units` JSON (`schema_version: "4"`)
+- Deterministic collection, projection, and snapshot-scoped identifiers
+- Structured logs on STDERR, artifact data on STDOUT or file output
+- Explicit partial-failure reporting with clean exit codes
+- Retrieval profile helpers for `flat_rag_v1` and `structured_rag_v1`
 
-* **Languages** – Python (`.py`) and Markdown (`.md`) only in v1.
-* **Outputs** – hierarchical or flat, envelope `JSON` or streaming `NDJSON`.
-* **Logging** – powered by `structlog`; fully STDOUT-safe.
-* **Fail-fast** – abort immediately on the first parser error if you need strict runs.
-* **Ignore rules** – `.repogptignore` (git-wildmatch) plus sensible defaults (`.git`, `node_modules`, …).
-* **Markdown fences** – both backtick (`` ``` ``) and tilde (`~~~`) delimiters; multi-word info strings (```` ```python console ````) use the first token as the language.
-
-Architecture and contracts:
-
-* structural IR and projections are treated as separate contracts
-* `code-units` v4 adds minimal hierarchy metadata for light structured retrieval
-* architecture, Phase 1 integration, and roadmap are documented in [docs/ARCHITECTURE.md](docs/ARCHITECTURE.md)
-
----
+See [docs/ARCHITECTURE.md](docs/ARCHITECTURE.md) for contract and architecture details, and [ROADMAP.md](ROADMAP.md) for future work only.
 
 ## Installation
 
 ```bash
 git clone https://github.com/Intrinsical-AI/RepoGPT.git
 cd RepoGPT
-```
-
-**Recommended** (reproducible via `uv.lock`):
-
-```bash
 uv sync
 ```
 
-**Alternative** (classic venv):
-
-```bash
-python -m venv .venv && source .venv/bin/activate
-pip install -e ".[dev]"
-```
-
----
-
-## Development and Code Quality
-
-This project uses [pre-commit](https://pre-commit.com) to enforce automated quality checks:
-
-- **Linting and auto-formatting** (`black`, `ruff`)
-- **Type checking** (`mypy`)
-- **Reproducible tests and checks** (`pytest -q`, `ruff`, `mypy`)
-
-**How do I contribute safely?**
-
-1. Install pre-commit once:
-    ```
-    pip install pre-commit
-    pre-commit install
-    ```
-
-2. Before committing, run all checks:
-    ```
-    pre-commit run --all-files
-    ```
-
-> If any check fails, **fix the code before pushing or opening a PR**.  
-> The CI pipeline is equally strict.
-
-
----
+RepoGPT uses `uv` as the supported local and CI bootstrap path.
 
 ## Quick start
 
 ```bash
-# analyse a codebase and emit a single JSON file
-repogpt path-to-project/ -o report.json
+# analyze a repository and write AST JSON to a file
+uv run repogpt path-to-project/ -o analysis.json
 
-# NDJSON streamed to stdout (great for pipes)
-repogpt path-to-project/ --flatten node --format ndjson --stdout | jq 'select(.record_type=="node" and .type=="class")'
+# stream AST NDJSON to stdout
+uv run repogpt path-to-project/ --format ndjson --flatten file --stdout
 
-# code-units projection for native RAG ingestion
-repogpt path-to-project/ --emit code-units --format json --stdout
+# emit retrieval-oriented code-units JSON
+uv run repogpt path-to-project/ --emit code-units --stdout
 
-# compare the two Phase 1 retrieval profiles on a `code-units` artifact
-python benchmark_retrieval_profiles.py code_units.json "helper"
-
+# compare the two built-in retrieval profiles over a code-units artifact
+uv run python benchmark_retrieval_profiles.py code_units.json "helper"
 ```
-
----
 
 ## CLI reference
 
-| Flag                       | Default         | Description                                                                                                                     |
-| -------------------------- | --------------- | ------------------------------------------------------------------------------------------------------------------------------- |
-| `--emit {ast,code-units}`  | `ast`           | `ast`: structural tree export in JSON or NDJSON.<br>`code-units`: retrieval projection in JSON only (`Py + Md`, schema `4`).   |
-| `--flatten {node,file}`    | `node`          | AST only. `node`: every node appears as an output record.<br>`file`: only the root node per file is emitted.                     |
-| `--format {json,ndjson}`   | `json`          | AST only. `json`: envelope with `stats`, `failures` and `records`.<br>`ndjson`: stream of `node`, `failure` and `summary`.      |
-| `--stdout`                 | -               | Stream to STDOUT instead of file.<br>Passing `-o /dev/stdout` has the same effect.                                              |
-| `-o, --output PATH`        | depends on emit | Destination file.<br>Defaults to `analysis.json` for AST and `code_units.json` for `code-units` if omitted.                    |
-| `--languages "py,md"`      | all parsers     | Comma-separated, case-insensitive whitelist of supported languages.                                                             |
-| `--include-tests`          | *off*           | Do **not** skip `tests/` directories, `test_*.py`, or `test-*.py` files.                                                       |
-| `--log-level {INFO,DEBUG}` | `INFO`          | Structured logs to STDERR.                                                                                                      |
-| `--fail-fast`              | *off*           | Abort on the first parser error (exit 1).                                                                                       |
+| Flag | Default | Description |
+| --- | --- | --- |
+| `--emit {ast,code-units}` | `ast` | `ast` emits the structural export. `code-units` emits the retrieval-oriented projection. |
+| `--flatten {node,file}` | `node` | AST only. `node` emits every node; `file` emits only the root node per file. |
+| `--format {json,ndjson}` | `json` | AST supports `json` and `ndjson`. `code-units` supports `json` only. |
+| `--stdout` | off | Write the artifact to STDOUT instead of a file. |
+| `-o, --output PATH` | depends on projection | Defaults to `analysis.json` for AST and `code_units.json` for `code-units`. |
+| `--languages "py,md"` | all supported parsers | Comma-separated, case-insensitive whitelist of enabled languages. |
+| `--include-tests` | off | Include `tests/` directories and `test_*.py` / `test-*.py` files. |
+| `--log-level {INFO,DEBUG}` | `INFO` | Structured log level for STDERR output. |
+| `--fail-fast` | off | Stop on the first parse error and return exit code `1`. |
 
-`--emit code-units` only supports `--format json`.
+Notes:
 
-AST JSON uses `records`; `code-units` JSON uses `documents`.
+- `--emit code-units` only supports `--format json`.
+- Passing `-o /dev/stdout` behaves like `--stdout`.
+- AST JSON uses `records`; `code-units` JSON uses `documents`.
 
 ### Exit codes
 
-| Code | Meaning                                                                 |
-| ---- | ----------------------------------------------------------------------- |
-| `0`  | All files parsed successfully.                                          |
-| `1`  | `--fail-fast` triggered: first parse error caused an early abort.       |
-| `2`  | Partial run: one or more files failed, artifact still emitted.          |
-| `3`  | Invalid repository path (not found, not a directory, permission denied).|
+| Code | Meaning |
+| --- | --- |
+| `0` | All collected files parsed successfully. |
+| `1` | `--fail-fast` stopped the run after the first parse error. |
+| `2` | Partial run: one or more files failed, artifact still emitted. |
+| `3` | Invalid repository path or unrecoverable runtime error. |
 
-> Without `--fail-fast` (the default), the tool always exits `0` or `2` — never `1` — even if files failed to parse.
+Without `--fail-fast`, runs return `0` or `2`, never `1`.
 
----
+## Collection and skip rules
 
-## `.repogptignore`
+RepoGPT collects files with a deterministic `rglob()` walk plus stable relative-path ordering. The public artifact contains parsed files and parse failures; skipped files remain internal implementation detail.
 
-Use the same glob syntax as `.gitignore` to exclude paths or files **in addition** to the built-in defaults.
+Built-in ignores are always excluded:
 
-**Built-in ignores** (always excluded, non-configurable):
+`.git`, `.hg`, `.svn`, `__pycache__`, `.venv`, `venv`, `env`, `.mypy_cache`, `.pytest_cache`, `dist`, `build`, `node_modules`, `.tox`, `.DS_Store`, `.idea`, `.vscode`
 
-`.git` · `.hg` · `.svn` · `__pycache__` · `.venv` · `venv` · `env` · `.mypy_cache` · `.pytest_cache` · `dist` · `build` · `node_modules` · `.tox` · `.DS_Store` · `.idea` · `.vscode`
+Additional collection rules:
 
-> Note: hidden files and directories (dotfiles) are **not** excluded by default unless they appear in the list above. Use `.repogptignore` to exclude them.
-> Files larger than **2 MB** are always skipped regardless of ignore rules.
+- `.repogptignore` uses gitignore-style matching via `pathspec`
+- test paths are skipped unless `--include-tests` is set
+- files larger than `2_000_000` bytes are skipped
+- symlinks are skipped
+- likely binary files are skipped
+- unsupported extensions are skipped before parsing
+
+Hidden files and directories are not excluded by default unless they match one of the built-in ignores or a `.repogptignore` rule.
+
+Example `.repogptignore`:
 
 ```gitignore
-# ignore generated docs
+# generated documentation
 docs/build/
 
-# ignore big assets
+# large assets
 *.png
 *.pdf
 ```
 
----
+## Artifact contracts
 
-## Output examples
+### AST export (`schema_version: "1"`)
 
-### 1. JSON envelope
+AST export is the direct structural projection of the internal `CodeNode` tree.
 
-```json
-{
-  "schema_version": "1",
-  "repo_root": "/abs/path/to/repo",
-  "stats": { "total_files": 3, "ok_files": 2, "failed_files": 1, "emitted_records": 2 },
-  "failures": [{ "record_type": "failure", "path": "bad.py", ... }],
-  "records": [{ "record_type": "node", "type": "module", "path": "src/app.py", ... }]
-}
-```
+- JSON payload keys: `schema_version`, `repo_root`, `stats`, `failures`, `records`
+- NDJSON record types: `node`, `failure`, `summary`
+- failure records include file digest information and parser error text
 
-### 2. NDJSON
+### Code-units (`schema_version: "4"`)
 
-```text
-{"record_type":"node","schema_version":"1","type":"module","path":"README.md","language":"md",...}
-{"record_type":"failure","schema_version":"1","path":"bad.py",...}
-{"record_type":"summary","schema_version":"1","repo_root":"/abs/path/to/repo",...}
-```
+`code-units` is the retrieval-oriented projection for downstream indexing and lightweight structured expansion.
 
-### 3. Code-units JSON
+Top-level payload fields:
 
-```json
-{
-  "schema_version": "4",
-  "kind": "code-units",
-  "repo_key": "my-repo",
-  "snapshot_id": "my-repo-4f1f0c9b8d1a2e3f",
-  "scope": "repogpt:my-repo",
-  "replace_scope": true,
-  "stats": { "total_files": 3, "ok_files": 2, "failed_files": 1, "emitted_documents": 4 },
-  "failures": [{ "path": "bad.py", "language": "py", "error": "...", "file": { "sha256": "...", "size": 42 } }],
-  "documents": [
-    {
-      "external_id": "repogpt:my-repo:src/app.py:function:helper",
-      "source_id": "repogpt:my-repo:file:src/app.py",
-      "repo_key": "my-repo",
-      "scope": "repogpt:my-repo",
-      "snapshot_id": "my-repo-4f1f0c9b8d1a2e3f",
-      "path": "src/app.py",
-      "language": "py",
-      "unit_type": "function",
-      "unit_level": "symbol",
-      "symbol": "helper",
-      "qualified_name": "helper",
-      "container_id": "repogpt:my-repo:src/app.py:module",
-      "depth": 1,
-      "ancestor_path": ["src/app.py"],
-      "start_line": 1,
-      "end_line": 2,
-      "content": "def helper():\n    return 1\n",
-      "content_hash": "f9f4c6f5d2b8d7c89d8f6d1e8c5dbe4f6f8ed0bdb0d85c6d7d064c93f8b5f4c9",
-      "docstring_present": false,
-      "has_children": false,
-      "metadata": {
-        "repo_key": "my-repo",
-        "path": "src/app.py",
-        "language": "py",
-        "unit_type": "function",
-        "unit_level": "symbol",
-        "symbol": "helper",
-        "qualified_name": "helper",
-        "container_id": "repogpt:my-repo:src/app.py:module",
-        "depth": 1,
-        "ancestor_path": ["src/app.py"],
-        "start_line": 1,
-        "end_line": 2,
-        "content_hash": "f9f4c6f5d2b8d7c89d8f6d1e8c5dbe4f6f8ed0bdb0d85c6d7d064c93f8b5f4c9",
-        "docstring_present": false,
-        "has_children": false,
-        "file": { "sha256": "...", "size": 42 },
-        "tags": [],
-        "attributes": {},
-        "dependencies": []
-      }
-    }
-  ]
-}
-```
+- `schema_version`
+- `kind`
+- `repo_key`
+- `snapshot_id`
+- `scope`
+- `replace_scope`
+- `stats`
+- `failures`
+- `documents`
 
-`--emit code-units` uses a dedicated public contract in schema `4`:
+Each document exposes retrieval-facing fields at the top level and duplicates them under `metadata` for generic import flows. Key fields include:
 
-* `external_id` is semantic and stable per unit, not derived from the internal AST `node.id`.
-* `content_hash` is `sha256(content)` for the exact emitted span and is the per-document change signal.
-* `snapshot_id` remains a repo-snapshot marker based on file hashes; it is provenance, not a per-document delta key.
-* `replace_scope: true` is emitted so canonical importers can do scope sync without extra wiring.
-* Canonical fields such as `path`, `language`, `unit_type`, `unit_level`, `symbol`, `qualified_name`, `container_id`, `depth`, `ancestor_path`, `start_line` and `end_line` live at the top level of each document and are duplicated in `metadata` for generic downstream filtering/import flows.
-* Hierarchy metadata is intentionally minimal: enough for light runtime expansion, not a full relation graph in every document.
-* If a file has no selected symbol/container units for its language, the projector falls back to emitting the root module document so the file still contributes a seedable unit.
+- `external_id`
+- `source_id`
+- `qualified_name`
+- `unit_level`
+- `container_id`
+- `depth`
+- `ancestor_path`
+- `content_hash`
+- `docstring_present`
+- `has_children`
 
----
+Contract notes:
 
-## MCP
+- `external_id` is the semantic public identifier for a projected document
+- `snapshot_id` is a repository-snapshot marker derived from collected file hashes
+- `content_hash` is `sha256(content)` for the exact emitted span
+- if a file produces no selected units for its language, the projector falls back to the root module document
 
-RepoGPT ships a compact MCP server for agent-facing artifact emission and profile comparison:
+## MCP interface
+
+RepoGPT ships a compact MCP server over stdio:
 
 ```bash
-repogpt-mcp
-# or: python -m repogpt.mcp_server
+uv run repogpt-mcp
+# or
+uv run python -m repogpt.mcp_server
 ```
 
-Tools:
+Transport and envelope:
 
-* `repogpt_emit_code_units`
-* `repogpt_emit_ast`
-* `repogpt_compare_profiles`
+- protocol: line-delimited JSON-RPC over stdio
+- initialization: `initialize`
+- tool discovery: `tools/list`
+- tool execution: `tools/call`
+- tool results are returned as JSON text content inside the JSON-RPC response
 
-The MCP surface is intentionally thin: it wraps the existing CLI and profile comparison script, and it does not introduce a separate artifact contract.
+Built-in tools:
 
----
+- `repogpt_emit_code_units`
+- `repogpt_emit_ast`
+- `repogpt_compare_profiles`
 
-## Logging & diagnostics
+Tool behavior summary:
 
-RepoGPT never mixes **data** and **logs**:
+- `repogpt_emit_code_units` returns `{"exit_code", "artifact", "stderr"}`
+- `repogpt_emit_ast` returns `{"exit_code", "artifact", "stderr"}`
+- `repogpt_compare_profiles` returns `{"exit_code", "comparison", "stderr"}`
 
-* Data → STDOUT (`--stdout`) or the output file.
-* Logs → STDERR (via `structlog`).
+`repogpt_compare_profiles` expects a path to an existing `code-units` artifact on disk.
 
-Examples:
+Minimal request example:
+
+```json
+{"jsonrpc":"2.0","id":1,"method":"initialize","params":{}}
+```
+
+## Retrieval profiles and benchmark path
+
+RepoGPT includes a small benchmark path for comparing two retrieval presets over a `code-units` artifact:
+
+- `flat_rag_v1`: rank documents and return the top `k` seeds without expansion
+- `structured_rag_v1`: rank documents, keep the same seeds, then add at most one enclosing container hop per seed when available
+
+The benchmark path is intended for contract-level comparison, not as a full retrieval engine or production-quality relevance evaluation.
+
+## Logging and diagnostics
+
+RepoGPT keeps data and logs separate:
+
+- artifact data -> STDOUT or output file
+- logs -> STDERR
+
+Example log lines:
 
 ```text
 2026-03-24 02:45:04 [info     ] starting run                   format=json repo=/abs/path/to/repo
@@ -283,82 +226,93 @@ Examples:
 SyntaxError: invalid syntax'
 ```
 
-Capture with `pytest`’s `caplog`, or redirect STDERR to a file in CI.
+## Development workflow
 
----
+### Pre-commit vs full validation
 
-## Development
+`pre-commit` is a fast local quality gate. In this repository it covers:
 
-Available `make` targets:
+- `ruff-format`
+- `ruff`
+- `mypy`
+
+It does not run `pytest`. Run the test suite separately before pushing or opening a PR.
+
+Setup and common commands:
+
+```bash
+uv run pre-commit install
+uv run pre-commit run --all-files
+uv run pytest -q
+```
+
+### Make targets
 
 | Target | Command | Description |
-|---|---|---|
-| `make lint` | `ruff check .` | Lint |
-| `make type` | `mypy src tests` | Type check |
-| `make test` | `pytest -q` | Run tests |
-| `make clean` | — | Remove `__pycache__`, `.pytest_cache`, `.pyc` |
+| --- | --- | --- |
+| `make lint` | `uv run ruff check .` | Lint the codebase |
+| `make type` | `uv run mypy src tests` | Run type checks |
+| `make test` | `uv run pytest -q` | Run the test suite |
+| `make clean` | cleanup helpers | Remove Python cache artifacts |
 
-Or run the raw commands directly without `make`.
+## Project layout
 
-### Project layout
-
-```
+```text
 src/repogpt/
-├── adapters/
-│   ├── fs/             # filesystem traversal, ignore logic, file loading
-│   ├── parsers/        # language-specific parsers and parser registry
-│   ├── projectors/     # AST and code-units projections
-│   └── writers/        # artifact serialization
-├── application/        # use-case orchestration and exit codes
-├── domain/             # analysis, file, node, and error models
-├── ports/              # adapter interfaces
-├── utils/              # helper functions and retrieval profiles
-└── app/cli.py          # entry-point
+  adapters/
+    fs/
+    parsers/
+    projectors/
+    writers/
+  application/
+  app/
+  domain/
+  ports/
+  utils/
+  mcp_server.py
+  runtime.py
+tests/
+docs/
 ```
 
-### Extending to another language
+High-level responsibilities:
 
-1. Create `src/repogpt/adapters/parsers/<lang>_parser.py` implementing `parse() -> CodeNode`.
-2. Register it in `src/repogpt/adapters/parsers/registry.py`.
-3. Add parser tests under `tests/unit/adapters/parsers/` and refresh fixtures or golden payloads if the CLI contract changes.
-4. Update docs and the supported-language contract before announcing it.
-
----
+- `runtime.py` wires the shared analysis runtime
+- `app/cli.py` exposes the CLI entry point
+- `mcp_server.py` exposes the MCP stdio server
+- `adapters/` contains filesystem, parser, projector, and writer implementations
+- `application/` contains use-case orchestration and exit-code policy
+- `domain/` contains analysis, file, node, and error models
 
 ## Tests
 
+Run the full suite with:
+
+```bash
+uv run pytest -q
 ```
-pytest -q
+
+Relevant coverage areas:
+
+- collector behavior and skip rules
+- Python and Markdown parser behavior
+- AST and `code-units` contract stability
+- CLI exit codes and partial-failure semantics
+- MCP parity with CLI outputs
+
+Targeted integration checks:
+
+```bash
+uv run pytest -q tests/integration/test_cli_contract.py
+uv run pytest -q tests/integration/test_mcp_server.py
 ```
 
-The suite exercises:
+## Additional documents
 
-* Collect / ignore rules (including relative-path test detection and race-condition file disappearance)
-* Markdown & Python parsers (tilde fences, multi-word info strings, deep-tree recursion safety)
-* JSON/NDJSON contract v1
-* Code-units publisher (qualified symbol IDs, module fallback, byte-accurate file hashing)
-* CLI exit codes and partial failures
-* Import-path isolation to ensure tests run against this checkout
-
----
-
-## Roadmap
-
-* **Next** – richer Python semantics without breaking schema v1
-* **Later** – caching by file-hash + parallel workers
-* **Later** – new languages once they meet the same contract
-
----
-
-## Design notes
-
-- [docs/ARCHITECTURE.md](docs/ARCHITECTURE.md) — architecture, contracts, invariants, and roadmap.
-- [docs/CHALLENGES.md](docs/CHALLENGES.md) — open design questions, roadmap trade-offs, known limitations.
-
----
+- [docs/ARCHITECTURE.md](docs/ARCHITECTURE.md): current architecture, public contracts, interfaces, and invariants
+- [docs/CHALLENGES.md](docs/CHALLENGES.md): open design questions and tradeoffs, not a committed roadmap
+- [ROADMAP.md](ROADMAP.md): future work after the current shipped baseline
 
 ## License
 
 [MIT](LICENSE)
-
-Happy hacking 💻

--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ uv sync
 ```
 
 RepoGPT uses `uv` as the supported local and CI bootstrap path.
+For development validation tools such as `pre-commit`, install the dev extra with `uv sync --extra dev`.
 
 ## Quick start
 
@@ -241,6 +242,7 @@ It does not run `pytest`. Run the test suite separately before pushing or openin
 Setup and common commands:
 
 ```bash
+uv sync --extra dev
 uv run pre-commit install
 uv run pre-commit run --all-files
 uv run pytest -q

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,209 +1,81 @@
-# RepoGPT Plan
+# RepoGPT Roadmap
 
-## Purpose
+This roadmap starts after the current shipped baseline:
 
-This document proposes a staged plan for evolving RepoGPT from:
+- CLI and MCP stdio interfaces
+- AST export (`schema_version: "1"`)
+- `code-units` (`schema_version: "4"`)
+- built-in retrieval profile comparison for `flat_rag_v1` and `structured_rag_v1`
 
-- a structural analyzer with useful projections
+The items below are forward-looking only.
 
-into:
+## Near-term priorities
 
-- a system with clear contracts for structure, projections, retrieval, and context assembly.
+### 1. Contract hardening and examples
 
-The goal is to keep Phase 1 small and executable, while leaving Phase 2 and Phase 3 as intentional directions rather than locked specifications.
+- add more end-to-end examples for CLI, MCP, and downstream `code-units` consumption
+- tighten contract coverage around edge cases that matter to external consumers
+- document extension points only where the interfaces are stable enough to maintain
 
-## Current Observation
+### 2. Performance evidence before optimization
 
-Today the repo already has:
+- add synthetic large-repository fixtures for reproducible collector and parser benchmarks
+- measure the cost of comment association, wide markdown trees, and large-file span extraction
+- only optimize hot paths that show sustained regressions under reproducible tests
 
-- a real structural tree (`CodeNode`) with parent/child relations
-- deterministic node ids
-- parser-specific semantics for Python and Markdown
-- AST and `code-units` projections
-- a projection intended for downstream RAG/indexing
+### 3. Better operational guidance
 
-What it does not yet have as a first-class contract:
+- publish clearer guidance for when to prefer AST vs `code-units`
+- add more examples of `.repogptignore` strategies for large or mixed repositories
+- expand troubleshooting guidance around partial failures and invalid inputs
 
-- retrieval contracts
-- context assembly contracts
-- official retrieval profiles
-- a benchmark that measures full retrieval/context behavior
+## Medium-term directions
 
-## Guiding Principles
+### 1. Relation-aware projections
 
-1. Separate structural IR from projections and from retrieval behavior.
-2. Keep the stable core small.
-3. Add only the minimum hierarchy needed to make runtime expansion possible.
-4. Prefer 1-2 official defaults over many flexible but underspecified options.
-5. Benchmark only after the relevant contract is explicit.
+- explore projections that preserve more structural context without turning the runtime into a graph engine
+- keep any new relation metadata optional, explicit, and contract-versioned
+- avoid freezing relation models that parser implementations cannot support reliably
 
----
+### 2. Incremental and cached analysis
 
-## Phase 1: Minimal Executable Foundation
+- evaluate file-hash-based reuse where it materially reduces repeated work
+- keep cache behavior optional and transparent to artifact consumers
+- preserve deterministic public outputs for the same repository snapshot
 
-This phase should be treated as the first concrete delivery target.
+### 3. Clearer extension boundaries
 
-### Objectives
+- document parser and projector extension patterns once they are stable enough for outside use
+- avoid promising plugin-style extensibility until the maintenance cost is understood
 
-- clarify the boundary between core structural IR and projected retrieval units
-- enrich `code-units` with minimum hierarchy metadata
-- define official default retrieval profiles at a product-contract level
-- enable a first meaningful benchmark for flat vs structured retrieval
+## Longer-term directions
 
-### Scope
+### 1. More language support
 
-#### 1. Core IR boundary
+- add new languages only when parser quality, tests, and contract semantics are good enough to match the Python/Markdown baseline
+- avoid expanding language support faster than the public contract can remain coherent
 
-Make the distinction explicit between:
+### 2. Richer retrieval and bundle policies
 
-- structural IR: canonical tree/graph entities produced by analysis
-- projections: materialized views derived from the IR
+- explore stronger retrieval semantics beyond one-hop container expansion
+- keep retrieval behavior layered on top of projections rather than coupled to parser internals
+- define bundle assembly policies explicitly before adding broader orchestration logic
 
-Phase 1 does not need a full public graph API. It only needs the contract boundary to be documented and stable enough for follow-on work.
+### 3. Agent-facing context assembly
 
-#### 2. Minimal `code-units` enrichment
+- evaluate context-bundle contracts only after projection and retrieval semantics are stable
+- keep agentic workflows out of scope until the non-agentic interfaces are mature and measurable
 
-Add only the metadata needed for light hierarchical expansion at retrieval time.
+## Guardrails
 
-Candidate minimum fields:
+The roadmap should preserve these constraints:
 
-- `qualified_name`
-- `unit_level` with initial values such as `symbol` and `container`
-- `depth`
-- `container_id` or equivalent stable container reference
-- `ancestor_path` or another compact ancestry representation
-- `docstring_present`
-- `has_children`
+- no regression in deterministic public artifacts
+- no silent contract changes without explicit versioning
+- no new supported language without parser tests and contract coverage
+- no optimization work without reproducible evidence that it is needed
 
-Notes:
+## Related documents
 
-- `parent_id` may be included if it can be made semantically useful for downstream consumers.
-- Avoid serializing full graph neighborhoods into every unit.
-- Keep compatibility and schema versioning explicit.
-
-#### 3. Official default profiles
-
-Define two official profiles first:
-
-- `flat_rag_v1`
-- `structured_rag_v1`
-
-Initial intent:
-
-- `flat_rag_v1`: symbol-centric, no hierarchical expansion, baseline-friendly
-- `structured_rag_v1`: symbol-first with light container expansion under budget
-
-These profiles do not need a full retrieval engine inside RepoGPT yet. They can start as documented contracts and reference behaviors for downstream consumers.
-
-#### 4. Phase 1 benchmark
-
-Add a benchmark/evaluation target that compares:
-
-- flat retrieval/bundle construction
-- structured retrieval/bundle construction
-
-The benchmark should measure more than raw retrieval hits. At minimum it should look at:
-
-- retrieval quality
-- final context size/tokens
-- expansion count
-- downstream task success where available
-
-### Non-goals
-
-Phase 1 should explicitly avoid:
-
-- full call-graph accuracy
-- a rich public `Edge` model for every relation type
-- agentic retrieval loops
-- RL or policy optimization
-- a general DSL for retrieval/query planning
-
-### Exit Criteria
-
-Phase 1 is done when:
-
-- the structural IR vs projection boundary is documented
-- `code-units` exposes minimal hierarchy metadata
-- `flat_rag_v1` and `structured_rag_v1` are defined
-- there is at least one benchmark path comparing flat vs structured behavior
-
----
-
-## Phase 2: Structured Retrieval Direction
-
-This phase is intentionally directional, not a closed spec.
-
-### Primary Direction
-
-Extend RepoGPT from "better retrieval units" toward "structured retrieval contracts".
-
-### Likely Areas
-
-- introduce a more explicit relation layer where useful
-- define lightweight projection families beyond plain symbol bodies
-- formalize retrieval modes and expansion policies
-- make bundle assembly more explicit and reproducible
-- expand benchmark coverage to include relation-aware retrieval
-
-### Examples of Phase 2 directions
-
-- relation-aware views such as imports, class members, local dependencies
-- explicit projection names such as `symbol_body`, `container_outline`, `symbol_plus_parent`
-- clearer retrieval modes such as exact, vector, hybrid, filter-then-rank
-- bundle-level policies for deduplication, ordering, and token budgeting
-
-### Constraints
-
-- do not let relation modeling outrun parser reliability
-- do not overfit contracts to Python-only assumptions
-- keep projections reusable outside any one retrieval strategy
-
----
-
-## Phase 3: Agentic Retrieval And Context Assembly Direction
-
-This phase is also directional, not a fixed spec.
-
-### Primary Direction
-
-Move from static retrieval profiles toward iterative, budget-aware, agent-compatible context assembly.
-
-### Likely Areas
-
-- formal `ContextBundle` contract
-- iterative retrieval/expansion loops
-- explicit budgets for tokens, calls, and expansion depth
-- projection caching and reuse
-- agentic benchmarks that measure multi-step retrieval behavior
-
-### Examples of Phase 3 directions
-
-- an `agentic_rag_v1` profile
-- runtime selection between symbol, container, and relation views
-- stop criteria for iterative expansion
-- provenance and coverage summaries in final bundles
-- latency-aware and budget-aware evaluation
-
-### Important Caution
-
-Agentic benchmarking should not be treated as the baseline benchmark. It belongs after the retrieval and bundle contracts are clear enough that results are interpretable.
-
----
-
-## Proposed Sequence
-
-1. Finish Phase 1 with minimal hierarchy and two official profiles.
-2. Use that to validate whether structured retrieval actually improves over flat retrieval.
-3. Only then decide how much of Phase 2 should become productized contracts.
-4. Treat Phase 3 as a later system layer, not as the starting point.
-
-## Short Version
-
-If this plan is followed, RepoGPT evolves in this order:
-
-1. stable structure
-2. useful projected units
-3. explicit retrieval profiles
-4. reproducible context assembly
-5. only then agentic behavior
+- [docs/ARCHITECTURE.md](docs/ARCHITECTURE.md): current system and public contracts
+- [docs/CHALLENGES.md](docs/CHALLENGES.md): open design questions and tradeoffs

--- a/benchmark_tree_utils.py
+++ b/benchmark_tree_utils.py
@@ -1,61 +1,145 @@
+from __future__ import annotations
+
 import time
 from collections.abc import Callable
 from typing import Any
-from repogpt.models import CodeNode
-from repogpt.utils.tree_utils import (
-    nodes_by_type,
-    all_comments,
-    all_docstrings,
-    all_tags,
-    nodes_where,
-    iter_nodes,
-)
+
+from repogpt.adapters.parsers.py_parser import PythonParser
+from repogpt.domain.nodes import CodeNode
+from repogpt.utils.tree_utils import flatten_tree, iter_nodes
 
 
-def build_tree(depth: int, width: int, id_prefix: str = "node") -> CodeNode:
-    node = CodeNode(
-        id=id_prefix,
-        type="function",
-        name=f"func_{id_prefix}",
-        docstring=f"Docstring for {id_prefix}" if depth % 2 == 0 else None,
-        comments=[{"text": "A comment", "line": 1}] if depth % 3 == 0 else [],
-        tags=["tag1", "tag2"] if depth % 4 == 0 else [],
+def build_balanced_tree(depth: int, width: int) -> CodeNode:
+    root = CodeNode(
+        id="root",
+        type="module",
+        name="root",
+        language="py",
+        path="benchmark.py",
+        start_line=1,
+        end_line=max(1, depth * width * width),
     )
-    if depth > 0:
-        for i in range(width):
-            child = build_tree(depth - 1, width, f"{id_prefix}_{i}")
-            child.parent_id = node.id
-            node.children.append(child)
-    return node
+    frontier = [root]
+    next_id = 1
+    next_line = 2
+    for level in range(depth):
+        next_frontier: list[CodeNode] = []
+        for parent in frontier:
+            for child_index in range(width):
+                node_type = "class" if level % 2 == 0 else "function"
+                child = CodeNode(
+                    id=f"node-{next_id}",
+                    type=node_type,
+                    name=f"{node_type}_{level}_{child_index}",
+                    language="py",
+                    path="benchmark.py",
+                    start_line=next_line,
+                    end_line=next_line,
+                    parent_id=parent.id,
+                )
+                next_id += 1
+                next_line += 1
+                parent.children.append(child)
+                next_frontier.append(child)
+        frontier = next_frontier
+    return root
+
+
+def build_nested_tree(depth: int) -> CodeNode:
+    root = CodeNode(
+        id="root",
+        type="module",
+        name="root",
+        language="py",
+        path="nested.py",
+        start_line=1,
+        end_line=depth * 2,
+    )
+    current = root
+    for index in range(1, depth + 1):
+        child = CodeNode(
+            id=f"node-{index}",
+            type="class" if index % 2 else "function",
+            name=f"node_{index}",
+            language="py",
+            path="nested.py",
+            start_line=index,
+            end_line=(depth * 2) - index,
+            parent_id=current.id,
+        )
+        current.children.append(child)
+        current = child
+    return root
+
+
+def build_comments(count: int, max_line: int) -> list[dict[str, Any]]:
+    comments: list[dict[str, Any]] = []
+    for index in range(count):
+        comments.append(
+            {
+                "text": f"comment {index}",
+                "line": 1 + (index % max_line),
+            }
+        )
+    return comments
+
+
+def reset_comments(root: CodeNode) -> None:
+    for node in iter_nodes(root):
+        node.comments.clear()
 
 
 def benchmark_function(func: Callable[..., Any], *args: Any, iterations: int = 10) -> float:
     start_time = time.perf_counter()
     for _ in range(iterations):
         func(*args)
-    end_time = time.perf_counter()
-    return (end_time - start_time) / iterations
+    return (time.perf_counter() - start_time) / iterations
+
+
+def benchmark_comment_association(
+    parser: PythonParser,
+    root: CodeNode,
+    comments: list[dict[str, Any]],
+    *,
+    iterations: int = 10,
+) -> float:
+    def run() -> None:
+        reset_comments(root)
+        parser._associate_comments(root, comments)
+
+    return benchmark_function(run, iterations=iterations)
+
+
+def main() -> int:
+    tree_root = build_balanced_tree(depth=6, width=4)
+    nested_root = build_nested_tree(depth=800)
+    parser = PythonParser()
+    comments = build_comments(count=2_000, max_line=nested_root.end_line or 1)
+
+    print("Balanced tree nodes:", len(iter_nodes(tree_root)))
+    print("Nested tree depth:", len(iter_nodes(nested_root)))
+    print("Synthetic comments:", len(comments))
+
+    iter_nodes_time = benchmark_function(iter_nodes, tree_root, iterations=25)
+    flatten_tree_time = benchmark_function(flatten_tree, tree_root, iterations=25)
+    associate_comments_time = benchmark_comment_association(
+        parser,
+        nested_root,
+        comments,
+        iterations=25,
+    )
+
+    reset_comments(nested_root)
+    parser._associate_comments(nested_root, comments)
+    attached_comments = sum(len(node.comments) for node in iter_nodes(nested_root))
+
+    print("\nBenchmark results")
+    print(f"iter_nodes:           {iter_nodes_time:.6f} seconds")
+    print(f"flatten_tree:         {flatten_tree_time:.6f} seconds")
+    print(f"associate_comments:   {associate_comments_time:.6f} seconds")
+    print(f"attached comments:    {attached_comments}")
+    return 0
 
 
 if __name__ == "__main__":
-    print("Building tree...")
-    # Depth 6, width 4 -> 1 + 4 + 16 + 64 + 256 + 1024 + 4096
-    root = build_tree(7, 3)
-    num_nodes = len(iter_nodes(root))
-    print(f"Tree built with {num_nodes} nodes.")
-
-    print("\nBenchmarking...")
-    t_nodes_by_type = benchmark_function(nodes_by_type, root, "function")
-    print(f"nodes_by_type: {t_nodes_by_type:.6f} seconds")
-
-    t_all_comments = benchmark_function(all_comments, root)
-    print(f"all_comments: {t_all_comments:.6f} seconds")
-
-    t_all_docstrings = benchmark_function(all_docstrings, root)
-    print(f"all_docstrings: {t_all_docstrings:.6f} seconds")
-
-    t_all_tags = benchmark_function(all_tags, root)
-    print(f"all_tags: {t_all_tags:.6f} seconds")
-
-    t_nodes_where = benchmark_function(nodes_where, root, lambda n: n.type == "function")
-    print(f"nodes_where: {t_nodes_where:.6f} seconds")
+    raise SystemExit(main())

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,364 +1,292 @@
-# RepoGPT - Architecture
+# RepoGPT Architecture
 
-> **Owners:** RepoGPT maintainers
-> **Scope:** current system architecture, public output contracts, Phase 1 interoperability layer, and near-term roadmap
-> **Out of scope:** downstream production retrieval infrastructure, graph-rich context assembly, and agentic orchestration loops
+> Owners: RepoGPT maintainers
+> Scope: current runtime composition, public contracts, interfaces, invariants, and operational boundaries
+> Out of scope: production retrieval infrastructure, graph-rich context assembly, and agentic orchestration loops
 
----
+## 1. System overview
 
-## 0) TL;DR
+RepoGPT analyzes a repository and emits deterministic artifacts derived from a canonical structural representation.
 
-- **What:** RepoGPT analyzes a source tree and emits deterministic structural artifacts for Python and Markdown. Its current value is a canonical structural IR plus derived projections for downstream indexing, retrieval, and evaluation.
-- **Why:** The system exists to turn repositories into stable, queryable artifacts that humans and LLM pipelines can consume without reimplementing parsing and structural normalization per consumer.
-- **How:**
-  - collect repository files under explicit ignore and size rules
-  - parse files into a canonical node tree
-  - materialize projections such as AST exports and `code-units`
-  - version public contracts explicitly
-  - keep retrieval profiles as interoperability presets, even when retrieval is executed outside RepoGPT
-- **Non-negotiables:**
-  - structural IR is canonical; projections are derived
-  - internal node ids are deterministic but snapshot-scoped
-  - public contracts are versioned
-  - `code-units` remains independently consumable
-  - Phase 1 retrieval stays light and one-hop; graph-rich retrieval stays out of scope
+Current supported languages:
 
----
+- Python (`.py`)
+- Markdown (`.md`)
 
-## 1) Goals, Non-goals, Constraints
+Shared runtime composition:
 
-### 1.1 Goals
+```text
+Collector -> Loader -> Parser registry -> Projector -> Writer
+```
 
-1. Produce a canonical structural representation of repository contents for supported languages.
-2. Provide stable, versioned projections for downstream indexing and retrieval.
-3. Keep interoperability layer small enough to be reliable and testable.
-4. Preserve room for richer retrieval and context assembly without prematurely freezing a full graph or agentic design.
+Concrete runtime wiring lives in `src/repogpt/runtime.py` and currently composes:
 
-### 1.2 Non-goals
+- `DefaultCollector`
+- `DefaultLoader`
+- `StaticParserRegistry`
+- `AstProjector`
+- `CodeUnitsProjector`
+- `ArtifactWriter`
 
-- A built-in production retrieval engine.
-- A full public graph API in Phase 1.
-- Perfect call-graph or reference analysis.
-- Agentic control loops, RL, or multi-step autonomous retrieval planning.
-- A general query DSL in the current phase.
+## 2. Architecture intent
 
-### 1.3 Constraints
+RepoGPT exists to keep three concerns separate:
 
-- Supported languages in scope today: Python and Markdown.
-- Contracts must remain deterministic and explicitly versioned.
-- Parser-emitted metadata varies by language and parser capability.
-- Output artifacts must stay consumable without requiring RepoGPT runtime state.
+1. collection and parsing into a canonical structural representation
+2. materialization of versioned public projections
+3. downstream retrieval experimentation that consumes projections rather than parser internals
 
-### 1.4 Quality attributes
+This separation keeps the structural core stable while allowing projection and retrieval behavior to evolve independently.
 
-| Attribute | Target | Measured by |
-| --------- | ------ | ----------- |
-| Determinism | same input snapshot yields equivalent artifacts | unit, golden, and integration tests |
-| Contract clarity | public fields have defined semantics | docs plus contract tests |
-| Evolvability | new retrieval behavior can be added without rewriting the IR | architecture review and API boundaries |
-| Partial-failure visibility | artifacts reflect parse failures explicitly | CLI and integration tests |
+## 3. Public interfaces today
 
----
+RepoGPT currently exposes two built-in public interfaces.
 
-## 2) Domain model
+### 3.1 CLI
 
-### 2.1 Glossary
+Entry point:
 
-- **Structural IR:** canonical structural representation produced by analysis.
-- **Node:** structural unit in the IR, such as module, class, function, method, heading, or code block.
-- **Projection:** materialized view derived from the IR.
-- **`code-units`:** retrieval-oriented projection intended for indexing and downstream filtering.
-- **Retrieval profile:** contract-level preset describing expected downstream retrieval semantics.
-- **Context assembly:** bundling retrieved items into the final input served to an LLM or similar consumer.
+- `repogpt`
 
-### 2.2 Bounded contexts
+Responsibilities:
 
-| Context | Responsibility | Owns data? | External deps | Public APIs |
-| ------- | -------------- | ---------: | ------------- | ----------- |
-| Collection and parsing | collect files and build structural IR | Yes | filesystem, Python AST | internal ports plus CLI flow |
-| Projections and contracts | turn IR into versioned artifacts | Yes | none beyond IR | AST JSON/NDJSON, `code-units` JSON |
-| Retrieval interoperability | define profile semantics and benchmark baselines | Yes | downstream consumers may execute retrieval | profile contracts, benchmark path |
+- validate runtime arguments
+- build an `AnalysisRequest`
+- run the shared analysis pipeline
+- emit the selected artifact to file or STDOUT
+- report clean exit codes and STDERR logs
 
-### 2.3 Entities and value objects
+### 3.2 MCP stdio server
 
-#### Entity: `CodeNode`
+Entry point:
 
-- **Identity:** deterministic internal id derived from path, type, name, span, and containment context.
-- **Lifecycle:** created by a parser, consumed by projectors, not directly exposed as the stable public retrieval id.
-- **Invariants:** see section 4.
-- **Context:** structural IR.
+- `repogpt-mcp`
 
-#### Value Object: `AnalysisResult`
+Transport:
 
-- **Equality:** value-based.
-- **Validation:** contains parsed files, failures, and summary stats for one analysis run.
+- line-delimited JSON-RPC over stdio
 
-#### Value Object: `AstProjection` / `CodeUnitsProjection`
+Built-in tools:
 
-- **Equality:** value-based public artifact envelope.
-- **Validation:** schema version plus contract-specific payload.
+- `repogpt_emit_code_units`
+- `repogpt_emit_ast`
+- `repogpt_compare_profiles`
 
----
+The MCP server reuses the same analysis runtime as the CLI. It does not introduce a separate artifact contract.
 
-## 3) Data and contract model
+## 4. Domain and projection model
 
-### 3.1 Structural IR
+### 4.1 Canonical structural representation
 
-The structural IR provides a canonical node tree with:
+The internal structural representation is a `CodeNode` tree with:
 
-- stable internal ids for a given snapshot and analysis pipeline
+- deterministic internal IDs for a given repository snapshot and analysis pipeline
 - containment relations
 - source spans
-- parser-emitted structural metadata
+- parser-emitted metadata such as comments, tags, metrics, attributes, and dependencies where supported
 
-Additional metadata such as comments, tags, metrics, or dependency-related attributes may be present when supported by a parser, but they are not all part of the minimal invariant core.
+Internal node IDs are deterministic but snapshot-scoped. They are not the stable public identifier for retrieval-facing consumers.
 
-Important identifier note:
-
-- internal node ids are deterministic for a given repository snapshot and analysis pipeline
-- internal node ids are not guaranteed to remain stable across refactors, line shifts, or containment changes
-- public consumers should treat `external_id`, not internal node id, as the semantic public identifier in `code-units`
-
-### 3.2 Projections
+### 4.2 Public projections
 
 RepoGPT currently exposes two projection families:
 
-- **AST export:** structural JSON or NDJSON representation of the node tree
-- **`code-units`:** retrieval-oriented JSON projection with high-signal units
+- AST export
+- `code-units`
 
 Projection rules:
 
-- projections are always derived from the structural IR
-- projections may omit structural detail for compactness
-- projections own public contract versioning
-- projections must remain consumable without needing in-memory IR state
+- projections are derived from the structural representation
+- projections own their public schema versions
+- projections remain consumable without in-memory runtime state
+- failure records remain explicit in the public payload
 
-### 3.3 `code-units` v4
+## 5. Public artifact contracts
 
-`code-units` v4 is the current retrieval-oriented public contract.
+### 5.1 AST export (`schema_version: "1"`)
 
-It adds minimal hierarchy metadata without embedding full graph neighborhoods into each document.
+AST export is the direct structural projection of parsed files.
 
-#### Field semantics
+Formats:
 
-| Field | Semantics |
-| ----- | --------- |
-| `unit_level` | one of `symbol` or `container` |
-| `qualified_name` | semantic name used for downstream identification within the projection; for file/module roots the relative path acts as the root identifier |
-| `container_id` | nearest enclosing container in the current IR, expressed as a semantic projection identifier |
-| `depth` | containment depth from the file/module root |
-| `ancestor_path` | ordered root-to-parent list of ancestor identifiers, represented in v4 as qualified-name-like strings |
-| `docstring_present` | whether the underlying structural node has a non-empty docstring |
-| `has_children` | whether the underlying structural node has direct children in the IR |
+- JSON envelope
+- NDJSON stream
+
+JSON payload keys:
+
+- `schema_version`
+- `repo_root`
+- `stats`
+- `failures`
+- `records`
+
+NDJSON record types:
+
+- `node`
+- `failure`
+- `summary`
+
+### 5.2 Code-units (`schema_version: "4"`)
+
+`code-units` is the retrieval-oriented projection.
+
+Top-level payload keys:
+
+- `schema_version`
+- `kind`
+- `repo_key`
+- `snapshot_id`
+- `scope`
+- `replace_scope`
+- `stats`
+- `failures`
+- `documents`
+
+Document-level fields with contract significance:
+
+- `external_id`
+- `source_id`
+- `path`
+- `language`
+- `unit_type`
+- `unit_level`
+- `symbol`
+- `qualified_name`
+- `container_id`
+- `depth`
+- `ancestor_path`
+- `start_line`
+- `end_line`
+- `content`
+- `content_hash`
+- `docstring_present`
+- `has_children`
 
 Contract notes:
 
-- `container_id` may reference a logical container that is not emitted as a standalone document in the same artifact.
-- `ancestor_path` is intended for lightweight structural filtering and bundling, not as a substitute for a full graph path model.
-- `external_id` remains the public semantic identifier for a projected document.
-- If a file yields no selected symbol or container units for its language, the projector falls back to the root module document so the file still contributes a seedable unit.
+- `external_id` is the semantic public identifier for a projected document
+- `content_hash` is `sha256(content)` for the exact emitted span
+- `snapshot_id` is a repository-snapshot provenance marker derived from collected file hashes
+- `replace_scope: true` supports scope-replacement import flows
+- canonical retrieval fields are duplicated under `metadata` for generic downstream filters/importers
+- if a file yields no selected symbol or container units for its language, the projector falls back to the root module document
 
-### 3.4 Mapping rules
+## 6. Retrieval profile semantics
 
-- Parser output -> structural IR: language-specific parser emits `CodeNode` trees.
-- Structural IR -> AST projection: direct structural export.
-- Structural IR -> `code-units`: selected units plus retrieval-oriented metadata.
-- Retrieval profile -> benchmark/bundle logic: operates on projected documents, not on raw parser state.
+RepoGPT includes lightweight retrieval helpers over `code-units`. These are interoperability helpers, not a built-in production retrieval engine.
 
----
+### 6.1 `flat_rag_v1`
 
-## 4) Invariants and validation
+- rank documents for a query
+- return the top `k` seed items
+- perform no structural expansion
 
-### 4.1 Phase 1 invariants
+### 6.2 `structured_rag_v1`
 
-- Structural IR is canonical; projections are derived.
-- Internal node ids are snapshot-scoped.
-- `code-units` v4 remains independently consumable.
-- Phase 1 retrieval profiles do not require a built-in retrieval engine.
-- `structured_rag_v1` is limited to light one-hop container-aware expansion.
-- Graph-rich retrieval and context bundles remain out of scope for Phase 1.
+- rank documents for a query
+- keep the same top `k` seed items
+- add at most one nearest enclosing container hop per seed when a projected container is available
+- deduplicate by `external_id`
 
-### 4.2 Contract invariants
+### 6.3 Benchmark scope
 
-- Every emitted `external_id` must be deterministic for a given artifact snapshot.
-- `path`, `unit_type`, and span fields must remain coherent.
-- `content_hash` must reflect the emitted content of the projected document.
-- `unit_level` values must stay within the documented set.
-- Failure records must remain explicit in artifact payloads.
+The benchmark path compares profile behavior on:
 
-### 4.3 Failure semantics
+- selected items
+- expansion count
+- rough token estimate
 
-- Parse failures are represented in emitted artifacts.
-- Partial success is allowed and reported.
-- Fail-fast mode stops on first parse error.
-- Missing or unsupported parser coverage is reflected in emitted results rather than hidden.
+It does not claim end-to-end task quality, production relevance quality, or agentic performance.
 
----
+## 7. Collection, parsing, and failure semantics
 
-## 5) Architecture style and layers
+### 7.1 Collection
 
-### 5.1 Style
+Collection behavior is deterministic and currently includes:
 
-- **Style:** hexagonal-leaning layered architecture
-- **Rationale:** the repo separates domain objects, application orchestration, ports, and adapters with enough discipline to keep parsers/projectors/writers swappable without introducing unnecessary framework complexity
-- **Tradeoffs:** retrieval and context assembly are not yet first-class subsystems, so some downstream behavior remains contract-defined rather than runtime-native
+- `rglob()` over the repository root
+- canonical relative-path sort
+- built-in ignore directories/files
+- optional `.repogptignore`
+- test exclusion by default
+- file-size guard
+- binary-file detection
+- symlink exclusion
 
-### 5.2 Layers
+### 7.2 Parsing and projection
 
-| Layer | Responsibilities | Must NOT contain |
-| ----- | ---------------- | ---------------- |
-| Domain | entities, stats, analysis value objects | filesystem and CLI logic |
-| Application | use-case orchestration | parser-specific logic |
-| Ports | contracts for adapters | concrete adapter behavior |
+For each collected file:
+
+1. load raw bytes and decoded text
+2. resolve parser by extension
+3. parse into a `CodeNode` tree
+4. record parse failures explicitly
+5. project the aggregate result to AST or `code-units`
+
+### 7.3 Failure and exit semantics
+
+Invariants:
+
+- parse failures remain visible in public payloads
+- partial success is allowed
+- fail-fast stops after the first parse error
+- invalid repository paths are reported cleanly
+
+Public exit-code policy:
+
+- `0`: success
+- `1`: fail-fast stopped on first parse error
+- `2`: partial run with emitted artifact
+- `3`: invalid path or unrecoverable runtime error
+
+## 8. Layers and dependency rules
+
+RepoGPT follows a hexagonal-leaning layered structure.
+
+| Layer | Responsibilities | Must not contain |
+| --- | --- | --- |
+| Domain | core entities and value objects | filesystem and CLI logic |
+| Application | use-case orchestration | parser-specific behavior |
+| Ports | adapter contracts | concrete adapter logic |
 | Adapters | filesystem, parsers, projectors, writers | cross-layer policy sprawl |
-| CLI | user-facing command surface | domain rules |
+| Interfaces | CLI and MCP entry points | domain implementation details |
 
-### 5.3 Dependency rules
+Dependency rule:
 
 ```text
 Domain       -> (nothing)
 Application  -> Domain
 Ports        -> Domain
 Adapters     -> Domain + Ports
-CLI          -> Application + Adapters + Domain
+Interfaces   -> Application + Adapters + Domain
 ```
 
-Rule: the structural IR must not depend on any concrete parser or retrieval implementation
+The structural representation must not depend on any concrete parser implementation or retrieval engine.
 
----
+## 9. Observability and operational boundaries
 
-## 6) Components and interactions
+Observability today:
 
-### 6.1 Main components
+- structured logs on STDERR
+- artifact data on STDOUT or file output
+- explicit failure records in the artifact payload
 
-- **Collector:** discovers files under ignore and size rules.
-- **Loader:** loads bytes and decoded text with digest information.
-- **Parser registry:** resolves parser by language/extension.
-- **Parsers:** produce structural IR nodes.
-- **Projectors:** materialize AST or `code-units` projections.
-- **Writer:** emits artifacts to file or stdout.
-- **Profile benchmark helpers:** compare Phase 1 retrieval profiles over `code-units` artifacts.
+Known operational boundaries:
 
-### 6.2 Main analysis flow
+- full-tree collection cost grows with filesystem size
+- Python comment association can become expensive on deep trees with dense comments
+- large files increase parser and span-extraction cost
 
-1. collect repository files
-2. load file contents and digests
-3. parse into structural IR
-4. accumulate failures and stats
-5. project to AST or `code-units`
-6. write artifact and return result
+These are implementation boundaries, not contract changes.
 
-### 6.3 Phase 1 benchmark flow
+## 10. Deliberately out of scope
 
-1. generate a `code-units` artifact
-2. rank `code-units` documents for a query
-3. assemble a `flat_rag_v1` bundle from the ranked documents with no expansion
-4. assemble a `structured_rag_v1` bundle with at most one container hop per seed
-5. compare item sets and rough bundle size
+The current architecture does not commit to:
 
----
-
-## 7) Interfaces and retrieval profiles
-
-### 7.1 Public interface today
-
-- **Primary built-in interface:** CLI
-- **Public artifact contracts:** AST JSON/NDJSON and `code-units` JSON
-- **No built-in HTTP or messaging interface is part of the current architecture**
-
-### 7.2 Retrieval profiles
-
-In Phase 1, retrieval profiles are contract-level interoperability presets rather than built-in retrieval implementations. They define expected downstream semantics even when retrieval is executed by external infrastructure.
-
-#### `flat_rag_v1`
-
-- primary input: ranked `code-units` documents
-- expansion: none
-- ranking: exact symbol matches get a stronger score, but the profile is not restricted to symbol-only documents
-- intent: baseline retrieval and reproducible comparison
-
-#### `structured_rag_v1`
-
-- primary input: ranked `code-units` documents
-- expansion: at most one hop to the nearest enclosing container, subject to budget
-- default interpretation: container-aware expansion for top ranked seeds, then deduplicate
-- intent: light structured retrieval without requiring a graph engine
-
----
-
-## 8) Performance, benchmarks, and observability
-
-### 8.1 Performance posture
-
-- primary current concern: deterministic artifact generation over large repositories
-- known future concerns: repeated tree traversals, caching, and incremental analysis
-
-### 8.2 Benchmark posture
-
-Phase 1 includes a small benchmark path for comparing `flat_rag_v1` and `structured_rag_v1`.
-
-This benchmark path validates profile behavior at a small scale. It is not, by itself, evidence of general retrieval quality, end-to-end usefulness, or agentic performance.
-
-### 8.3 Observability
-
-- structured logs to stderr
-- artifact data to stdout or file
-- failure records in the emitted payload
-
----
-
-## 9) Testing strategy
-
-| Type | Scope | Tools | Required gates |
-| ---- | ----- | ----- | -------------- |
-| Unit | parsers, projectors, utils | `pytest` | required |
-| Integration | CLI and golden contracts | `pytest` | required |
-| Contract | schema and payload shape | tests plus golden fixtures | required |
-| Benchmark smoke | profile comparison path | script plus targeted tests | optional but expected in active development |
-
----
-
-## 10) Roadmap
-
-### 10.1 Phase 1
-
-- canonical structural IR vs projection boundary
-- `code-units` v4 hierarchy metadata
-- `flat_rag_v1` and `structured_rag_v1`
-- minimal benchmark path for profile comparison
-
-### 10.2 Phase 2 direction
-
-- explicit relation-aware projections where parser support is reliable
-- stronger retrieval semantics beyond one-hop container expansion
-- clearer bundle assembly policies
-
-### 10.3 Phase 3 direction
-
-- context bundle contracts
-- graph-richer retrieval
+- a built-in production retrieval engine
+- graph-rich public relation APIs
+- context-bundle contracts
 - agentic orchestration loops
-- more representative end-to-end evaluation
+- full call-graph or reference-graph accuracy
 
----
-
-## 11) Repo layout and conventions
-
-```text
-src/repogpt/
-  domain/
-  application/
-  ports/
-  adapters/
-  app/
-  utils/
-tests/
-docs/
-```
-
-Conventions:
-
-- keep domain and contract semantics small and explicit
-- version public artifacts intentionally
-- prefer parser-specific enrichment over pretending all metadata is universal
-- keep future retrieval execution decoupled from the structural core
+Future work is tracked in [ROADMAP.md](../ROADMAP.md). Open design questions live in [docs/CHALLENGES.md](CHALLENGES.md).

--- a/docs/CHALLENGES.md
+++ b/docs/CHALLENGES.md
@@ -1,65 +1,70 @@
-## Key Considerations and Open Challenges
+# Open Challenges and Design Questions
 
-* **Language support:**
-  In the short term, the focus is `Py + Md`. Any additional language should only be added once it has a parser, tests, and an output contract at the same level of stability.
+This document captures open questions and tradeoffs. It is not a committed roadmap.
 
-* **Views / projections implementation complexity:**
-  How easy should it be for a user to define a custom code view, for example: imports only, classes only, functions plus docstrings, and so on?
+## 1. Projection surface area
 
-  * **Code-driven:** very flexible, but a higher barrier for less technical users.
-  * **Configuration / DSL-driven:** more accessible, but requires design work and extra parsing.
-  * *Key decision:* balance flexibility against ease of use.
+RepoGPT currently ships AST export and `code-units`. An open question is how much additional projection flexibility should become part of the supported public surface.
 
-* **Performance:**
-  Analyzing large repositories can be expensive in time and memory, especially when multiple passes are involved (parse, process, report). It will be important to:
+Options under consideration:
 
-  * optimize tree traversals,
-  * cache intermediate results,
-  * offer “fast” versus “complete” modes.
+- code-driven extension points with high flexibility and a higher maintenance bar
+- configuration-driven views with lower technical overhead but more product and parsing design work
 
-* **Parser maturity and quality:**
-  Extraction quality depends heavily on the parsers (AST, tokenization, heuristics).
+The constraint is to avoid promising a flexible projection system before the long-term support cost is understood.
 
-  * Python has native support in the standard library. Markdown needs its own heuristics and golden tests to avoid degrading the tree.
-  * Parsers should be heavily exercised with real edge cases from the fixtures directory.
+## 2. Performance and scaling
 
-* **Competition and alternatives:**
-  There are advanced tools such as ctags, tree-sitter, linters, static analysis, doc generators, and IDEs that already cover parts of this problem.
+Large repositories stress the current runtime in predictable places:
 
-  * **RepoGPT differentiation:** unified analysis, structured and queryable output, explicit LLM/RAG orientation, and extensibility.
+- deterministic collection via full-tree traversal and stable sort
+- Python comment association on deep or dense trees
+- parsing and span extraction for large files
 
-* **Potential use cases beyond LLMs:**
+Open questions:
 
-  * Automatic documentation generation: API skeletons, module summaries.
-  * Internal and external dependency analysis.
-  * Code smell detection or custom pattern detection.
-  * Assisted refactoring: understanding impact, dependencies, and entry points.
-  * Visual maps, diagrams, and metrics for architects and developers.
+- which bottlenecks deserve dedicated benchmarks first
+- whether defensive guards are preferable to broad optimization
+- when incremental analysis or caching becomes worth the added complexity
 
+## 3. Parser maturity
 
-## TODOs and Improvement Opportunities
+Python and Markdown are intentionally the only supported languages today. The main challenge is not adding more parsers quickly; it is maintaining stable semantics and contract quality for the languages already in scope.
 
-1. **Parallelization and caching**
+Open questions:
 
-   * Introduce parallel processing per file or per node.
-   * Cache syntax trees for repositories with incremental changes.
+- which parser-emitted metadata is reliable enough to document as contract-level expectation
+- how much parser-specific enrichment can be added without creating a misleading cross-language abstraction
+- which real-world edge cases should be promoted into golden or integration fixtures
 
-2. **Implement the reporter**
+## 4. Retrieval semantics beyond the current baseline
 
-   * Generate dependency graphs, for example with Graphviz.
-   * Add metrics for code complexity, test coverage, and comment ratio.
+The current retrieval helpers are intentionally small and contract-focused. They are useful for comparison but do not yet answer broader questions about retrieval quality or context assembly policy.
 
-3. **Interactive UI / UX**
+Open questions:
 
-   * A lightweight web app with filterable views (imports, TODOs, docstrings).
-   * IDE integration only after the artifact contract is stabilized.
+- what additional structure is worth exposing without turning public artifacts into graph snapshots
+- how to evaluate retrieval behavior beyond overlap and simple expansion counts
+- when bundle-level policies should become explicit public contract instead of benchmark-only behavior
 
-4. **Incremental release strategy**
+## 5. Extension boundaries
 
-   * Consolidate `Py + Md` before opening up new languages.
-   * Create concrete use-case examples such as code RAG, audits, and structured diffs.
+RepoGPT is internally modular, but that does not automatically mean every internal seam should become public extension API.
 
-5. **Ecosystem and collaboration**
+Open questions:
 
-   * Document the adapter and processor APIs clearly.
-   * Open up real extensibility only once the v1 schema has proven stable.
+- which parser, projector, or writer seams are stable enough to document for external use
+- how much plugin-like extensibility is realistic without raising support costs sharply
+- whether extensibility should stay code-centric or grow a supported configuration surface
+
+## 6. Product positioning
+
+RepoGPT overlaps with tools such as tree-sitter-based analyzers, static analysis tooling, documentation generators, and indexing pipelines. The open challenge is to keep the product boundary clear.
+
+Current differentiation:
+
+- deterministic repository abstraction
+- explicit public artifact contracts
+- support for both human-facing and LLM-facing downstream consumers
+
+The open question is how far RepoGPT should expand beyond artifact generation without diluting that core.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,7 +38,6 @@ dev = [
   "ruff>=0.0.291", 
   "mypy>=1.0",
   "pre-commit>=2.20",
-  "black>=23.1.0",
   "coverage>=6.4"
 ]
 
@@ -59,32 +58,21 @@ build-backend = "setuptools.build_meta"
 
 
 [tool.setuptools]
-license-files = ["LICENSE", "LICENSE.md"]
+license-files = ["LICENSE"]
 package-dir   = {"" = "src"}
 
 [tool.setuptools.packages.find]
 where = ["src"]
 
 
-[tool.black]
-line-length = 88
-exclude = '''
-(
-    tests/data/
-  | tests/fixtures/
-)
-'''
-
-
 [tool.ruff]
-# misma selección que `black --target-version py311`
 line-length = 100
-target-version = "py311"
+target-version = "py310"
 exclude = ["src/repogpt/__init__.py", "tests/data", "tests/fixtures"]
 
 [tool.mypy]
 strict = true
-python_version = "3.11"
+python_version = "3.10"
 mypy_path = ["src"]
 ignore_missing_imports = true
 exclude = ["tests/data/", "tests/fixtures/"]

--- a/src/repogpt/__init__.py
+++ b/src/repogpt/__init__.py
@@ -1,15 +1,7 @@
-# repogpt/__init__.py
+from __future__ import annotations
 
-# Versión del paquete
+import logging
 
 __version__ = "0.8.3"
-
-# Opcional: importar elementos clave para acceso directo
-# from .analyzer import RepositoryAnalyzer
-# from .exceptions import RepoGPTException
-
-# Configurar un logger NullHandler por defecto para evitar mensajes si la app
-# que usa la librería no configura logging.
-import logging
 
 logging.getLogger(__name__).addHandler(logging.NullHandler())

--- a/src/repogpt/adapters/fs/collector.py
+++ b/src/repogpt/adapters/fs/collector.py
@@ -41,7 +41,7 @@ def load_pathspec(repo_root: Path) -> pathspec.PathSpec | None:
                     line for line in handle if line.strip() and not line.strip().startswith("#")
                 ]
             return pathspec.PathSpec.from_lines("gitignore", lines)
-    except OSError:
+    except (OSError, ValueError, UnicodeError):
         logger.warning("failed to read repogptignore", path=str(ignore_file))
     return None
 

--- a/src/repogpt/app/cli.py
+++ b/src/repogpt/app/cli.py
@@ -7,16 +7,12 @@ from pathlib import Path
 
 import structlog
 
-from repogpt.adapters.fs.collector import DefaultCollector
-from repogpt.adapters.fs.loader import DefaultLoader
 from repogpt.adapters.parsers.registry import StaticParserRegistry
-from repogpt.adapters.projectors.ast_projector import AstProjector
-from repogpt.adapters.projectors.code_units_projector import CodeUnitsProjector
 from repogpt.adapters.writers.artifact_writer import ArtifactWriter
-from repogpt.application.analyze_repo import AnalyzeRepo
 from repogpt.application.exit_codes import exit_code_for_result
 from repogpt.domain.analysis import AnalysisRequest, OutputTarget
 from repogpt.domain.errors import InvalidRepoError
+from repogpt.runtime import build_analyze_repo
 
 LEVELS: dict[str, int] = {"DEBUG": logging.DEBUG, "INFO": logging.INFO}
 
@@ -50,7 +46,6 @@ def main() -> int:  # noqa: D401
     parser.add_argument("-o", "--output")
     parser.add_argument("--languages")
     parser.add_argument("--emit", choices=["ast", "code-units"], default="ast")
-    # phase‑3 flags
     parser.add_argument("--log-level", choices=["INFO", "DEBUG"], default="INFO")
     parser.add_argument("--fail-fast", action="store_true")
 
@@ -92,14 +87,7 @@ def main() -> int:  # noqa: D401
     log.info("starting run", repo=str(request.repo_root), format=request.format)
 
     try:
-        result = AnalyzeRepo(
-            collector=DefaultCollector(),
-            loader=DefaultLoader(),
-            parser_registry=registry,
-            ast_projector=AstProjector(),
-            code_units_projector=CodeUnitsProjector(),
-            writer=ArtifactWriter(),
-        ).run(request)
+        result = build_analyze_repo(ArtifactWriter()).run(request)
         if result.stopped_early and result.stats.failed_files > 0:
             first_failure = next(
                 parsed_file.failure.message

--- a/src/repogpt/mcp_server.py
+++ b/src/repogpt/mcp_server.py
@@ -6,15 +6,9 @@ import json
 import logging
 import sys
 from pathlib import Path
-from typing import Any
+from typing import Any, Literal, cast
 
 from repogpt import __version__
-from repogpt.adapters.fs.collector import DefaultCollector
-from repogpt.adapters.fs.loader import DefaultLoader
-from repogpt.adapters.parsers.registry import StaticParserRegistry
-from repogpt.adapters.projectors.ast_projector import AstProjector
-from repogpt.adapters.projectors.code_units_projector import CodeUnitsProjector
-from repogpt.application.analyze_repo import AnalyzeRepo
 from repogpt.domain.analysis import (
     AnalysisRequest,
     AstProjection,
@@ -22,6 +16,7 @@ from repogpt.domain.analysis import (
     OutputTarget,
 )
 from repogpt.application.exit_codes import exit_code_for_result
+from repogpt.runtime import build_analyze_repo
 from repogpt.utils.retrieval_profiles import compare_profiles
 
 logging.basicConfig(level=logging.INFO, format="%(message)s", stream=sys.stderr)
@@ -44,12 +39,12 @@ class _CaptureWriter:
 def _build_request(
     *,
     repo_path: str,
-    emit: str,
+    emit: Literal["ast", "code-units"],
     include_tests: bool,
     languages: list[str] | None,
     fail_fast: bool,
-    flatten: str | None = None,
-    fmt: str = "json",
+    flatten: Literal["node", "file"] | None = None,
+    fmt: Literal["json", "ndjson"] = "json",
 ) -> AnalysisRequest:
     return AnalysisRequest(
         repo_root=Path(repo_path).resolve(),
@@ -65,13 +60,13 @@ def _build_request(
 
 def _run_repogpt_analysis(
     *,
-    emit: str,
+    emit: Literal["ast", "code-units"],
     repo_path: str,
     include_tests: bool,
     languages: list[str] | None,
     fail_fast: bool,
-    flatten: str | None = None,
-    fmt: str = "json",
+    flatten: Literal["node", "file"] | None = None,
+    fmt: Literal["json", "ndjson"] = "json",
 ) -> dict[str, Any]:
     request = _build_request(
         repo_path=repo_path,
@@ -83,22 +78,18 @@ def _run_repogpt_analysis(
         fmt=fmt,
     )
     capture_writer = _CaptureWriter()
-    result = AnalyzeRepo(
-        collector=DefaultCollector(),
-        loader=DefaultLoader(),
-        parser_registry=StaticParserRegistry(),
-        ast_projector=AstProjector(),
-        code_units_projector=CodeUnitsProjector(),
-        writer=capture_writer,
-    ).run(request)
+    result = build_analyze_repo(capture_writer).run(request)
     if capture_writer.projection is None:
         raise RuntimeError("RepoGPT analysis did not produce a projection.")
+    if fmt == "json":
+        artifact: dict[str, Any] | list[dict[str, Any]] = capture_writer.projection.json_payload
+    else:
+        projection = cast(AstProjection, capture_writer.projection)
+        artifact = projection.ndjson_records
 
     return {
         "exit_code": exit_code_for_result(result),
-        "artifact": capture_writer.projection.json_payload
-        if fmt == "json"
-        else capture_writer.projection.ndjson_records,
+        "artifact": artifact,
         "stderr": "",
     }
 
@@ -136,8 +127,8 @@ def tool_emit_ast(
         include_tests=include_tests,
         languages=languages,
         fail_fast=fail_fast,
-        flatten=flatten,
-        fmt=format,
+        flatten=cast(Literal["node", "file"], flatten),
+        fmt=cast(Literal["json", "ndjson"], format),
     )
 
 

--- a/src/repogpt/runtime.py
+++ b/src/repogpt/runtime.py
@@ -1,0 +1,20 @@
+from __future__ import annotations
+
+from repogpt.adapters.fs.collector import DefaultCollector
+from repogpt.adapters.fs.loader import DefaultLoader
+from repogpt.adapters.parsers.registry import StaticParserRegistry
+from repogpt.adapters.projectors.ast_projector import AstProjector
+from repogpt.adapters.projectors.code_units_projector import CodeUnitsProjector
+from repogpt.application.analyze_repo import AnalyzeRepo
+from repogpt.ports.writers import ArtifactWriterPort
+
+
+def build_analyze_repo(writer: ArtifactWriterPort) -> AnalyzeRepo:
+    return AnalyzeRepo(
+        collector=DefaultCollector(),
+        loader=DefaultLoader(),
+        parser_registry=StaticParserRegistry(),
+        ast_projector=AstProjector(),
+        code_units_projector=CodeUnitsProjector(),
+        writer=writer,
+    )

--- a/src/repogpt/utils/tree_utils.py
+++ b/src/repogpt/utils/tree_utils.py
@@ -1,4 +1,3 @@
-from collections.abc import Callable
 from typing import Any
 
 from repogpt.domain.nodes import CodeNode
@@ -44,30 +43,6 @@ def iter_nodes(root: CodeNode) -> list[CodeNode]:
     return nodes
 
 
-# === Query-tree utils
-
-
-def nodes_by_type(root: CodeNode, type_: str) -> list[dict[str, Any]]:
-    """Devuelve todos los nodos del árbol de un tipo dado."""
-    return [_node_to_dict(n) for n in iter_nodes(root) if n.type == type_]
-
-
 def all_comments(root: CodeNode) -> list[dict[str, Any]]:
     """Devuelve todos los comentarios de todos los nodos."""
     return [dict(c) for n in iter_nodes(root) for c in n.comments]
-
-
-def all_docstrings(root: CodeNode) -> list[str | None]:
-    """Devuelve todos los docstrings de los nodos (si existen)."""
-    return [n.docstring for n in iter_nodes(root) if n.docstring]
-
-
-def all_tags(root: CodeNode) -> list[str]:
-    """Devuelve todos los tags de todos los nodos."""
-    return [tag for n in iter_nodes(root) for tag in n.tags]
-
-
-# Avanzado: filtrado por predicado arbitrario
-def nodes_where(root: CodeNode, predicate: Callable[[CodeNode], bool]) -> list[dict[str, Any]]:
-    """Devuelve nodos que cumplen una condición arbitraria."""
-    return [_node_to_dict(n) for n in iter_nodes(root) if predicate(n)]

--- a/tests/README.md
+++ b/tests/README.md
@@ -1,11 +1,17 @@
-# ¡Piensa con cabeza!
+# Test Suite Notes
 
-Por mucho que recomiende chatGPT o Gemini, en lugar de hacer fixtures para los casos, al ser un módulo de parsing; tiene sentido que hagamos los test a la vieja usanza: definiendo nuestros propios archivos hardcodeados
+This directory mixes unit tests, integration tests, golden payloads, and parser fixtures.
 
-```
-basic.py
-edge_cases.py
-docstring_examples.py
-basic.md
-with_comments.md
+Current layout:
+
+- `tests/unit/`: focused tests for adapters, application logic, runtime wiring, and utilities
+- `tests/integration/`: CLI and MCP contract coverage
+- `tests/golden/`: stable payload fixtures for public artifact contracts
+- `tests/data/`: parser-oriented sample files and edge cases
+- `tests/fixtures/`: small fixture repositories for end-to-end contract tests
+
+Run the full suite with:
+
+```bash
+uv run pytest -q
 ```

--- a/tests/integration/test_mcp_server.py
+++ b/tests/integration/test_mcp_server.py
@@ -5,15 +5,19 @@ import os
 import subprocess
 import sys
 from pathlib import Path
+from typing import Any, cast
 
 from repogpt.mcp_server import handle_request
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
 SRC_ROOT = REPO_ROOT / "src"
 CLI_FIXTURE = REPO_ROOT / "tests" / "fixtures" / "cli_repo"
+JsonDict = dict[str, Any]
 
 
-def _run(args: list[str], repo_path: Path = CLI_FIXTURE) -> subprocess.CompletedProcess[str]:
+def _run(
+    args: list[str], repo_path: Path = CLI_FIXTURE, *, cwd: Path | None = None
+) -> subprocess.CompletedProcess[str]:
     env = dict(os.environ)
     existing_pythonpath = env.get("PYTHONPATH")
     env["PYTHONPATH"] = (
@@ -23,27 +27,75 @@ def _run(args: list[str], repo_path: Path = CLI_FIXTURE) -> subprocess.Completed
         [sys.executable, "-m", "repogpt.app.cli", *args, str(repo_path)],
         capture_output=True,
         text=True,
-        cwd=REPO_ROOT,
+        cwd=str(cwd or REPO_ROOT),
         env=env,
     )
 
 
-def _read_json(path: Path) -> dict[str, object]:
-    return json.loads(path.read_text(encoding="utf-8"))
+def _write_mcp_mixed_fixture(root: Path) -> None:
+    (root / "src").mkdir()
+    (root / "tests").mkdir()
+    (root / "docs").mkdir()
+    (root / "ignored").mkdir()
+
+    (root / "src" / "service.py").write_text(
+        "def helper() -> str:\n    return 'service'\n\n"
+        "class Demo:\n    def helper(self) -> str:\n        return 'method'\n",
+        encoding="utf-8",
+    )
+    (root / "tests" / "test_service.py").write_text(
+        "def test_helper() -> None:\n    assert helper() == 'service'\n",
+        encoding="utf-8",
+    )
+    (root / "docs" / "guide.md").write_text(
+        "# Title\n"
+        "## Details\n"
+        "Intro\n"
+        "## Details\n"
+        "More\n"
+        "### Subheading\n"
+        "### Subheading\n"
+        "### Details\n"
+        "# Footer\n",
+        encoding="utf-8",
+    )
+    (root / "ignored" / "skip.py").write_text(
+        "def ignored() -> None:\n    return None\n",
+        encoding="utf-8",
+    )
+    (root / ".repogptignore").write_text("ignored/\n", encoding="utf-8")
 
 
-def _extract_content_text(response: dict[str, object]) -> dict[str, object]:
-    result = response["result"]  # type: ignore[index]
-    content = result["content"]  # type: ignore[index]
-    return json.loads(content[0]["text"])  # type: ignore[index]
+def _json_lines(stdout: str) -> list[JsonDict]:
+    return [json.loads(line) for line in stdout.splitlines() if line.strip()]
+
+
+def _read_json(path: Path) -> JsonDict:
+    return cast(JsonDict, json.loads(path.read_text(encoding="utf-8")))
+
+
+def _extract_content_text(response: JsonDict) -> JsonDict:
+    result = cast(JsonDict, response["result"])
+    content = cast(list[JsonDict], result["content"])
+    return cast(JsonDict, json.loads(cast(str, content[0]["text"])))
+
+
+def _assert_payloads_equivalent(
+    cli_payload: JsonDict,
+    mcp_payload: JsonDict,
+) -> None:
+    assert cli_payload["schema_version"] == mcp_payload["schema_version"]
+    assert cli_payload["kind"] == mcp_payload["kind"]
+    assert cli_payload["stats"] == mcp_payload["stats"]
+    assert cli_payload["documents"] == mcp_payload["documents"]
 
 
 def test_mcp_initialize_and_list_tools() -> None:
     initialize = handle_request({"jsonrpc": "2.0", "id": 1, "method": "initialize", "params": {}})
-    assert initialize["result"]["serverInfo"]["name"] == "repogpt"  # type: ignore[index]
+    assert initialize["result"]["serverInfo"]["name"] == "repogpt"
 
     listed = handle_request({"jsonrpc": "2.0", "id": 2, "method": "tools/list", "params": {}})
-    names = {tool["name"] for tool in listed["result"]["tools"]}  # type: ignore[index]
+    names = {tool["name"] for tool in listed["result"]["tools"]}
     assert {
         "repogpt_emit_code_units",
         "repogpt_emit_ast",
@@ -132,3 +184,105 @@ def test_mcp_compare_profiles_uses_code_units_artifact(tmp_path: Path) -> None:
     assert "flat_rag_v1" in comparison
     assert "structured_rag_v1" in comparison
     assert _read_json(artifact_path)["kind"] == "code-units"
+
+
+def test_mcp_end_to_end_mixed_repo_matches_cli_across_flags(tmp_path: Path) -> None:
+    repo_root = tmp_path / "repo"
+    repo_root.mkdir()
+    _write_mcp_mixed_fixture(repo_root)
+    resolved_repo_root = repo_root.resolve()
+
+    for include_tests in (False, True):
+        include_tests_arg = ["--include-tests"] if include_tests else []
+        cli_run = _run(
+            ["--stdout", "--format", "json", "--emit", "code-units", *include_tests_arg],
+            resolved_repo_root,
+            cwd=tmp_path,
+        )
+        assert cli_run.returncode == 0
+        cli_payload = json.loads(cli_run.stdout)
+
+        response = handle_request(
+            {
+                "jsonrpc": "2.0",
+                "id": 6,
+                "method": "tools/call",
+                "params": {
+                    "name": "repogpt_emit_code_units",
+                    "arguments": {
+                        "repo_path": str(resolved_repo_root),
+                        "include_tests": include_tests,
+                    },
+                },
+            }
+        )
+
+        mcp_payload_response = _extract_content_text(response)
+        assert mcp_payload_response["exit_code"] == 0
+        mcp_payload = cast(JsonDict, mcp_payload_response["artifact"])
+        _assert_payloads_equivalent(cli_payload, mcp_payload)
+
+        cli_ast = _run(
+            ["--stdout", "--format", "ndjson", "--flatten", "file", *include_tests_arg],
+            resolved_repo_root,
+            cwd=tmp_path,
+        )
+        assert cli_ast.returncode == 0
+        cli_records = _json_lines(cli_ast.stdout)
+        assert cli_records[-1]["record_type"] == "summary"
+        assert cli_records[-1]["schema_version"] == "1"
+
+        response_ast = handle_request(
+            {
+                "jsonrpc": "2.0",
+                "id": 7,
+                "method": "tools/call",
+                "params": {
+                    "name": "repogpt_emit_ast",
+                    "arguments": {
+                        "repo_path": str(resolved_repo_root),
+                        "format": "ndjson",
+                        "flatten": "file",
+                        "include_tests": include_tests,
+                    },
+                },
+            }
+        )
+        mcp_ast_payload = _extract_content_text(response_ast)
+        assert mcp_ast_payload["exit_code"] == 0
+        mcp_ast = cast(list[JsonDict], mcp_ast_payload["artifact"])
+        assert mcp_ast[-1]["record_type"] == "summary"
+        assert mcp_ast[-1]["schema_version"] == "1"
+
+    artifact = _run(
+        ["--stdout", "--format", "json", "--emit", "code-units", "--include-tests"],
+        resolved_repo_root,
+        cwd=tmp_path,
+    )
+    artifact_json = json.loads(artifact.stdout)
+    comparison_input = tmp_path / "code_units.json"
+    comparison_input.write_text(
+        json.dumps(artifact_json, ensure_ascii=False, indent=2), encoding="utf-8"
+    )
+
+    compare = handle_request(
+        {
+            "jsonrpc": "2.0",
+            "id": 8,
+            "method": "tools/call",
+            "params": {
+                "name": "repogpt_compare_profiles",
+                "arguments": {
+                    "artifact_path": str(comparison_input),
+                    "query": "helper",
+                },
+            },
+        }
+    )
+
+    comparison_payload = _extract_content_text(compare)
+    assert comparison_payload["exit_code"] == 0
+    comparison = cast(JsonDict, comparison_payload["comparison"])
+    assert comparison["query_text"] == "helper"
+    assert "flat_rag_v1" in comparison
+    assert "structured_rag_v1" in comparison

--- a/tests/unit/adapters/fs/test_collector.py
+++ b/tests/unit/adapters/fs/test_collector.py
@@ -4,6 +4,8 @@ import os
 from pathlib import Path
 from unittest.mock import patch
 
+import pathspec
+
 from repogpt.adapters.fs.collector import DefaultCollector, ignore_reason, should_ignore
 from repogpt.domain.analysis import AnalysisRequest
 
@@ -144,3 +146,104 @@ def test_collect_skips_file_that_disappears_during_stat(tmp_path: Path) -> None:
     assert len(files) == 1
     assert files[0].relative_path == "stable.py"
     assert any(item.relative_path == "vanishing.py" for item in skipped)
+
+
+def test_collect_handles_invalid_repogptignore_pattern_without_failing(tmp_path: Path) -> None:
+    (tmp_path / ".repogptignore").write_text("[invalid\n", encoding="utf-8")
+    (tmp_path / "keep.py").write_text("print('ok')", encoding="utf-8")
+    (tmp_path / "skip.py").write_text("print('no')", encoding="utf-8")
+
+    collector = DefaultCollector()
+
+    def raise_pattern_error(*args: object, **kwargs: object) -> pathspec.PathSpec:
+        _ = args, kwargs
+        raise ValueError("invalid pattern")
+
+    with patch.object(pathspec.PathSpec, "from_lines", raise_pattern_error):
+        files, skipped = collector.collect(AnalysisRequest(repo_root=tmp_path), {"py"})
+
+    assert {item.relative_path for item in files} == {"keep.py", "skip.py"}
+    assert {item.relative_path for item in skipped} == {".repogptignore"}
+
+
+def test_collect_treats_ambiguous_binary_without_null_as_text(tmp_path: Path) -> None:
+    (tmp_path / "ambiguous.py").write_bytes(b"\xff\xfe\xfd" + b"x = 1")
+
+    files, skipped = DefaultCollector().collect(AnalysisRequest(repo_root=tmp_path), {"py"})
+
+    assert any(item.relative_path == "ambiguous.py" for item in files)
+    assert {item.relative_path for item in skipped} == set()
+
+
+def test_collect_skips_symlinks_by_default(tmp_path: Path) -> None:
+    (tmp_path / "real.py").write_text("x=1", encoding="utf-8")
+    (tmp_path / "link_to_real.py").symlink_to("real.py")
+
+    files, skipped = DefaultCollector().collect(AnalysisRequest(repo_root=tmp_path), {"py"})
+
+    assert any(item.relative_path == "real.py" for item in files)
+    assert any(
+        item.relative_path == "link_to_real.py" and item.reason == "symlink" for item in skipped
+    )
+
+
+def test_collect_handles_long_relative_paths_in_output(tmp_path: Path) -> None:
+    nested = tmp_path
+    for _ in range(3):
+        nested = nested / ("nested_" + "x" * 40)
+        nested.mkdir()
+    (nested / ("module_" + "y" * 120 + ".py")).write_text("x = 1", encoding="utf-8")
+
+    files, skipped = DefaultCollector().collect(AnalysisRequest(repo_root=tmp_path), {"py"})
+
+    assert len(skipped) == 0
+    assert len(files) == 1
+    assert files[0].relative_path.endswith("module_" + "y" * 120 + ".py")
+
+
+def test_collect_on_large_synthetic_repo_stable_order_and_test_filter(tmp_path: Path) -> None:
+    for index in range(180):
+        suffix = "py" if index % 2 == 0 else "md"
+        if index % 11 == 0:
+            folder = "tests"
+            name = f"module_{index:03d}.{'py' if index % 4 == 0 else 'md'}"
+        elif index % 7 == 0:
+            folder = "package"
+            name = f"test_{index:03d}." + suffix
+        else:
+            folder = f"pkg_{index % 13}"
+            name = f"file_{index:03d}." + suffix
+
+        path = tmp_path / folder / name
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(f"value = {index}", encoding="utf-8")
+
+    expected_all = sorted(
+        path.relative_to(tmp_path).as_posix()
+        for path in tmp_path.rglob("*")
+        if path.is_file() and path.suffix.lstrip(".").lower() in {"py", "md"}
+    )
+
+    expected_without_tests = [
+        item
+        for item in expected_all
+        if not item.startswith("tests/") and not Path(item).name.startswith(("test_", "test-"))
+    ]
+    expected_with_tests = [
+        item for item in expected_all if item.endswith(".py") or item.endswith(".md")
+    ]
+
+    files_default, skipped_default = DefaultCollector().collect(
+        AnalysisRequest(repo_root=tmp_path, include_tests=False),
+        {"py", "md"},
+    )
+    files_include_tests, skipped_include = DefaultCollector().collect(
+        AnalysisRequest(repo_root=tmp_path, include_tests=True),
+        {"py", "md"},
+    )
+
+    assert [item.relative_path for item in files_default] == expected_without_tests
+    assert [item.relative_path for item in files_include_tests] == expected_with_tests
+    assert skipped_default
+    assert any(item.reason == "tests_excluded" for item in skipped_default)
+    assert not skipped_include

--- a/tests/unit/adapters/parsers/test_py_parser.py
+++ b/tests/unit/adapters/parsers/test_py_parser.py
@@ -234,3 +234,102 @@ def test_associate_comments_attaches_to_deepest_containing_node() -> None:
     assert inner.comments == [{"text": "inside inner", "line": 4}]
     assert outer.comments == [{"text": "inside outer only", "line": 2}]
     assert root.comments == [{"text": "outside all", "line": 11}]
+
+
+def test_associate_comments_handles_boundary_lines_and_many_items_without_misrouting() -> None:
+    parser = PythonParser()
+    root = CodeNode(
+        id="root",
+        type="module",
+        name="root",
+        language="py",
+        path="root.py",
+        start_line=1,
+        end_line=40,
+    )
+    outer = CodeNode(
+        id="outer",
+        type="class",
+        name="Outer",
+        language="py",
+        path="root.py",
+        start_line=3,
+        end_line=25,
+        parent_id="root",
+    )
+    inner = CodeNode(
+        id="inner",
+        type="method",
+        name="inner",
+        language="py",
+        path="root.py",
+        start_line=8,
+        end_line=18,
+        parent_id="outer",
+    )
+    other = CodeNode(
+        id="other",
+        type="function",
+        name="other",
+        language="py",
+        path="root.py",
+        start_line=30,
+        end_line=38,
+        parent_id="root",
+    )
+    root.children.extend([outer, other])
+    outer.children.append(inner)
+
+    comments = [
+        {"text": "before_first", "line": 1},
+        {"text": "before_outer", "line": 2},
+        {"text": "inside_outer", "line": 6},
+        {"text": "inside_inner", "line": 9},
+        {"text": "inside_other", "line": 30},
+        {"text": "after_all", "line": 99},
+    ]
+    parser._associate_comments(root, comments)
+
+    assert root.comments == [
+        {"text": "before_first", "line": 1},
+        {"text": "before_outer", "line": 2},
+        {"text": "after_all", "line": 99},
+    ]
+    assert outer.comments == [{"text": "inside_outer", "line": 6}]
+    assert inner.comments == [{"text": "inside_inner", "line": 9}]
+    assert other.comments == [{"text": "inside_other", "line": 30}]
+
+
+def test_associate_comments_with_many_comment_lines_stays_deterministic_and_fast() -> None:
+    parser = PythonParser()
+    depth = 800
+    root = CodeNode(
+        id="root",
+        type="module",
+        name="root",
+        language="py",
+        path="root.py",
+        start_line=1,
+        end_line=depth,
+    )
+    current = root
+    for index in range(1, depth):
+        child = CodeNode(
+            id=f"node-{index}",
+            type="function",
+            name=f"f{index}",
+            language="py",
+            path="root.py",
+            start_line=index,
+            end_line=index,
+            parent_id=current.id,
+        )
+        current.children.append(child)
+        current = child
+
+    comments = [{"text": f"comment {index}", "line": index} for index in range(1, depth, 2)]
+    parser._associate_comments(root, comments)
+
+    seen_comments = all_comments(root)
+    assert len(seen_comments) == len(comments)
+    assert {comment["line"] for comment in seen_comments} == {entry["line"] for entry in comments}

--- a/tests/unit/adapters/projectors/test_code_units_projector.py
+++ b/tests/unit/adapters/projectors/test_code_units_projector.py
@@ -150,3 +150,128 @@ def test_code_units_projection_markdown_falls_back_to_module(tmp_path: Path) -> 
 
     assert len(payload["documents"]) == 1
     assert _document(payload)["unit_type"] == "module"
+
+
+def test_code_units_projection_preserves_scope_unicity_for_symbol_collisions(
+    tmp_path: Path,
+) -> None:
+    content = """
+def helper():
+    return "global"
+
+
+class Demo:
+    def helper(self):
+        return "method"
+
+    class Inner:
+        def helper(self):
+            return "inner"
+
+def outer_helper():
+    pass
+"""
+
+    parsed_file = _python_parsed_file(tmp_path, "sample.py", content)
+    projection = (
+        CodeUnitsProjector()
+        .project(
+            AnalysisResult(
+                parsed_files=[parsed_file],
+                skipped_files=[],
+                stats=AnalysisStats(total_files=1, ok_files=1, failed_files=0, skipped_files=0),
+            ),
+            AnalysisRequest(repo_root=tmp_path),
+        )
+        .json_payload
+    )
+
+    documents = _documents(projection)
+    external_ids = [document["external_id"] for document in documents]
+    qualified_names = [document["qualified_name"] for document in documents]
+
+    assert len(external_ids) == len(set(external_ids))
+    assert len(qualified_names) == len(set(qualified_names))
+    helpers = [document for document in documents if document["symbol"] == "helper"]
+    assert {document["unit_type"] for document in helpers} == {"function", "method"}
+    assert any(document["unit_type"] == "function" for document in helpers)
+    assert any(document["unit_type"] == "method" for document in helpers)
+    assert any(document["qualified_name"] == "helper" for document in helpers)
+    assert any(document["qualified_name"] == "Demo.helper" for document in helpers)
+    assert any(document["qualified_name"] == "Demo.Inner.helper" for document in helpers)
+
+
+def test_code_units_projection_markdown_duplicate_headings_are_ordinalized(tmp_path: Path) -> None:
+    parsed_file = _markdown_parsed_file(
+        tmp_path,
+        "README.md",
+        "# Title\n"
+        "## Details\n"
+        "Some text\n"
+        "## Details\n"
+        "Other text\n"
+        "### Subheading\n"
+        "## Details\n"
+        "Third\n",
+    )
+
+    projection = (
+        CodeUnitsProjector()
+        .project(
+            AnalysisResult(
+                parsed_files=[parsed_file],
+                skipped_files=[],
+                stats=AnalysisStats(total_files=1, ok_files=1, failed_files=0, skipped_files=0),
+            ),
+            AnalysisRequest(repo_root=tmp_path),
+        )
+        .json_payload
+    )
+
+    qualified_names = [document["qualified_name"] for document in _documents(projection)]
+    heading_names = [
+        name for name in qualified_names if name.startswith("title") or "details" in name
+    ]
+
+    assert "title/details" in heading_names
+    assert "title/details-2" in heading_names
+    assert "title/details-3" in heading_names
+
+
+def test_code_units_projection_is_stable_with_unicode_path_and_invalid_utf8_content(
+    tmp_path: Path,
+) -> None:
+    path = tmp_path / "códigö.py"
+    content = b"def hello() -> str:\n" b"    # saludo\xff\n" b"    return 'ok'\n"
+    path.write_bytes(content)
+    raw = path.read_bytes()
+
+    sample = LoadedFile(
+        collected_file=CollectedFile(
+            abs_path=path,
+            relative_path=path.name,
+            language="py",
+        ),
+        raw_bytes=raw,
+        text=raw.decode("utf-8", errors="replace"),
+        digest=FileDigest(size=len(raw), sha256=hashlib.sha256(raw).hexdigest()),
+    )
+    parsed_file = ParsedFile(loaded_file=sample, root=PythonParser().parse(sample))
+    result = AnalysisResult(
+        parsed_files=[parsed_file],
+        skipped_files=[],
+        stats=AnalysisStats(total_files=1, ok_files=1, failed_files=0, skipped_files=0),
+    )
+
+    first_request = AnalysisRequest(repo_root=tmp_path)
+    second_request = AnalysisRequest(repo_root=tmp_path)
+    projection = CodeUnitsProjector().project(result, first_request).json_payload
+    projection2 = CodeUnitsProjector().project(result, second_request).json_payload
+    documents = _documents(projection)
+    documents2 = _documents(projection2)
+
+    assert documents[0]["path"] == path.name
+    assert documents == documents2
+    content_hash = hashlib.sha256(documents[0]["content"].encode("utf-8")).hexdigest()
+    assert content_hash == documents[0]["content_hash"]
+    assert "�" in documents[0]["content"]

--- a/tests/unit/adapters/projectors/test_code_units_projector.py
+++ b/tests/unit/adapters/projectors/test_code_units_projector.py
@@ -242,7 +242,7 @@ def test_code_units_projection_is_stable_with_unicode_path_and_invalid_utf8_cont
     tmp_path: Path,
 ) -> None:
     path = tmp_path / "códigö.py"
-    content = b"def hello() -> str:\n" b"    # saludo\xff\n" b"    return 'ok'\n"
+    content = b"def hello() -> str:\n    # saludo\xff\n    return 'ok'\n"
     path.write_bytes(content)
     raw = path.read_bytes()
 

--- a/tests/unit/application/test_analyze_repo.py
+++ b/tests/unit/application/test_analyze_repo.py
@@ -3,27 +3,16 @@ from __future__ import annotations
 import json
 from pathlib import Path
 
-from repogpt.adapters.fs.collector import DefaultCollector
-from repogpt.adapters.fs.loader import DefaultLoader
-from repogpt.adapters.parsers.registry import StaticParserRegistry
-from repogpt.adapters.projectors.ast_projector import AstProjector
-from repogpt.adapters.projectors.code_units_projector import CodeUnitsProjector
 from repogpt.adapters.writers.artifact_writer import ArtifactWriter
 from repogpt.application.analyze_repo import AnalyzeRepo
 from repogpt.application.exit_codes import exit_code_for_result
 from repogpt.domain.analysis import AnalysisRequest, OutputTarget
 from repogpt.domain.errors import InvalidRepoError
+from repogpt.runtime import build_analyze_repo
 
 
 def _use_case() -> AnalyzeRepo:
-    return AnalyzeRepo(
-        collector=DefaultCollector(),
-        loader=DefaultLoader(),
-        parser_registry=StaticParserRegistry(),
-        ast_projector=AstProjector(),
-        code_units_projector=CodeUnitsProjector(),
-        writer=ArtifactWriter(),
-    )
+    return build_analyze_repo(ArtifactWriter())
 
 
 def test_analyze_repo_success_returns_zero(tmp_path: Path) -> None:

--- a/tests/unit/test_runtime.py
+++ b/tests/unit/test_runtime.py
@@ -1,0 +1,22 @@
+from __future__ import annotations
+
+from repogpt.adapters.fs.collector import DefaultCollector
+from repogpt.adapters.fs.loader import DefaultLoader
+from repogpt.adapters.parsers.registry import StaticParserRegistry
+from repogpt.adapters.projectors.ast_projector import AstProjector
+from repogpt.adapters.projectors.code_units_projector import CodeUnitsProjector
+from repogpt.adapters.writers.artifact_writer import ArtifactWriter
+from repogpt.application.analyze_repo import AnalyzeRepo
+from repogpt.runtime import build_analyze_repo
+
+
+def test_build_analyze_repo_uses_canonical_runtime_components() -> None:
+    use_case = build_analyze_repo(ArtifactWriter())
+
+    assert isinstance(use_case, AnalyzeRepo)
+    assert isinstance(use_case.collector, DefaultCollector)
+    assert isinstance(use_case.loader, DefaultLoader)
+    assert isinstance(use_case.parser_registry, StaticParserRegistry)
+    assert isinstance(use_case.ast_projector, AstProjector)
+    assert isinstance(use_case.code_units_projector, CodeUnitsProjector)
+    assert isinstance(use_case.writer, ArtifactWriter)

--- a/uv.lock
+++ b/uv.lock
@@ -3,68 +3,12 @@ revision = 3
 requires-python = ">=3.10"
 
 [[package]]
-name = "black"
-version = "26.3.1"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "click" },
-    { name = "mypy-extensions" },
-    { name = "packaging" },
-    { name = "pathspec" },
-    { name = "platformdirs" },
-    { name = "pytokens" },
-    { name = "tomli", marker = "python_full_version < '3.11'" },
-    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/e1/c5/61175d618685d42b005847464b8fb4743a67b1b8fdb75e50e5a96c31a27a/black-26.3.1.tar.gz", hash = "sha256:2c50f5063a9641c7eed7795014ba37b0f5fa227f3d408b968936e24bc0566b07", size = 666155, upload-time = "2026-03-12T03:36:03.593Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/32/a8/11170031095655d36ebc6664fe0897866f6023892396900eec0e8fdc4299/black-26.3.1-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:86a8b5035fce64f5dcd1b794cf8ec4d31fe458cf6ce3986a30deb434df82a1d2", size = 1866562, upload-time = "2026-03-12T03:39:58.639Z" },
-    { url = "https://files.pythonhosted.org/packages/69/ce/9e7548d719c3248c6c2abfd555d11169457cbd584d98d179111338423790/black-26.3.1-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:5602bdb96d52d2d0672f24f6ffe5218795736dd34807fd0fd55ccd6bf206168b", size = 1703623, upload-time = "2026-03-12T03:40:00.347Z" },
-    { url = "https://files.pythonhosted.org/packages/7f/0a/8d17d1a9c06f88d3d030d0b1d4373c1551146e252afe4547ed601c0e697f/black-26.3.1-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:6c54a4a82e291a1fee5137371ab488866b7c86a3305af4026bdd4dc78642e1ac", size = 1768388, upload-time = "2026-03-12T03:40:01.765Z" },
-    { url = "https://files.pythonhosted.org/packages/52/79/c1ee726e221c863cde5164f925bacf183dfdf0397d4e3f94889439b947b4/black-26.3.1-cp310-cp310-win_amd64.whl", hash = "sha256:6e131579c243c98f35bce64a7e08e87fb2d610544754675d4a0e73a070a5aa3a", size = 1412969, upload-time = "2026-03-12T03:40:03.252Z" },
-    { url = "https://files.pythonhosted.org/packages/73/a5/15c01d613f5756f68ed8f6d4ec0a1e24b82b18889fa71affd3d1f7fad058/black-26.3.1-cp310-cp310-win_arm64.whl", hash = "sha256:5ed0ca58586c8d9a487352a96b15272b7fa55d139fc8496b519e78023a8dab0a", size = 1220345, upload-time = "2026-03-12T03:40:04.892Z" },
-    { url = "https://files.pythonhosted.org/packages/17/57/5f11c92861f9c92eb9dddf515530bc2d06db843e44bdcf1c83c1427824bc/black-26.3.1-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:28ef38aee69e4b12fda8dba75e21f9b4f979b490c8ac0baa7cb505369ac9e1ff", size = 1851987, upload-time = "2026-03-12T03:40:06.248Z" },
-    { url = "https://files.pythonhosted.org/packages/54/aa/340a1463660bf6831f9e39646bf774086dbd8ca7fc3cded9d59bbdf4ad0a/black-26.3.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:bf9bf162ed91a26f1adba8efda0b573bc6924ec1408a52cc6f82cb73ec2b142c", size = 1689499, upload-time = "2026-03-12T03:40:07.642Z" },
-    { url = "https://files.pythonhosted.org/packages/f3/01/b726c93d717d72733da031d2de10b92c9fa4c8d0c67e8a8a372076579279/black-26.3.1-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:474c27574d6d7037c1bc875a81d9be0a9a4f9ee95e62800dab3cfaadbf75acd5", size = 1754369, upload-time = "2026-03-12T03:40:09.279Z" },
-    { url = "https://files.pythonhosted.org/packages/e3/09/61e91881ca291f150cfc9eb7ba19473c2e59df28859a11a88248b5cbbc4d/black-26.3.1-cp311-cp311-win_amd64.whl", hash = "sha256:5e9d0d86df21f2e1677cc4bd090cd0e446278bcbbe49bf3659c308c3e402843e", size = 1413613, upload-time = "2026-03-12T03:40:10.943Z" },
-    { url = "https://files.pythonhosted.org/packages/16/73/544f23891b22e7efe4d8f812371ab85b57f6a01b2fc45e3ba2e52ba985b8/black-26.3.1-cp311-cp311-win_arm64.whl", hash = "sha256:9a5e9f45e5d5e1c5b5c29b3bd4265dcc90e8b92cf4534520896ed77f791f4da5", size = 1219719, upload-time = "2026-03-12T03:40:12.597Z" },
-    { url = "https://files.pythonhosted.org/packages/dc/f8/da5eae4fc75e78e6dceb60624e1b9662ab00d6b452996046dfa9b8a6025b/black-26.3.1-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:b5e6f89631eb88a7302d416594a32faeee9fb8fb848290da9d0a5f2903519fc1", size = 1895920, upload-time = "2026-03-12T03:40:13.921Z" },
-    { url = "https://files.pythonhosted.org/packages/2c/9f/04e6f26534da2e1629b2b48255c264cabf5eedc5141d04516d9d68a24111/black-26.3.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:41cd2012d35b47d589cb8a16faf8a32ef7a336f56356babd9fcf70939ad1897f", size = 1718499, upload-time = "2026-03-12T03:40:15.239Z" },
-    { url = "https://files.pythonhosted.org/packages/04/91/a5935b2a63e31b331060c4a9fdb5a6c725840858c599032a6f3aac94055f/black-26.3.1-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:0f76ff19ec5297dd8e66eb64deda23631e642c9393ab592826fd4bdc97a4bce7", size = 1794994, upload-time = "2026-03-12T03:40:17.124Z" },
-    { url = "https://files.pythonhosted.org/packages/e7/0a/86e462cdd311a3c2a8ece708d22aba17d0b2a0d5348ca34b40cdcbea512e/black-26.3.1-cp312-cp312-win_amd64.whl", hash = "sha256:ddb113db38838eb9f043623ba274cfaf7d51d5b0c22ecb30afe58b1bb8322983", size = 1420867, upload-time = "2026-03-12T03:40:18.83Z" },
-    { url = "https://files.pythonhosted.org/packages/5b/e5/22515a19cb7eaee3440325a6b0d95d2c0e88dd180cb011b12ae488e031d1/black-26.3.1-cp312-cp312-win_arm64.whl", hash = "sha256:dfdd51fc3e64ea4f35873d1b3fb25326773d55d2329ff8449139ebaad7357efb", size = 1230124, upload-time = "2026-03-12T03:40:20.425Z" },
-    { url = "https://files.pythonhosted.org/packages/f5/77/5728052a3c0450c53d9bb3945c4c46b91baa62b2cafab6801411b6271e45/black-26.3.1-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:855822d90f884905362f602880ed8b5df1b7e3ee7d0db2502d4388a954cc8c54", size = 1895034, upload-time = "2026-03-12T03:40:21.813Z" },
-    { url = "https://files.pythonhosted.org/packages/52/73/7cae55fdfdfbe9d19e9a8d25d145018965fe2079fa908101c3733b0c55a0/black-26.3.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:8a33d657f3276328ce00e4d37fe70361e1ec7614da5d7b6e78de5426cb56332f", size = 1718503, upload-time = "2026-03-12T03:40:23.666Z" },
-    { url = "https://files.pythonhosted.org/packages/e1/87/af89ad449e8254fdbc74654e6467e3c9381b61472cc532ee350d28cfdafb/black-26.3.1-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:f1cd08e99d2f9317292a311dfe578fd2a24b15dbce97792f9c4d752275c1fa56", size = 1793557, upload-time = "2026-03-12T03:40:25.497Z" },
-    { url = "https://files.pythonhosted.org/packages/43/10/d6c06a791d8124b843bf325ab4ac7d2f5b98731dff84d6064eafd687ded1/black-26.3.1-cp313-cp313-win_amd64.whl", hash = "sha256:c7e72339f841b5a237ff14f7d3880ddd0fc7f98a1199e8c4327f9a4f478c1839", size = 1422766, upload-time = "2026-03-12T03:40:27.14Z" },
-    { url = "https://files.pythonhosted.org/packages/59/4f/40a582c015f2d841ac24fed6390bd68f0fc896069ff3a886317959c9daf8/black-26.3.1-cp313-cp313-win_arm64.whl", hash = "sha256:afc622538b430aa4c8c853f7f63bc582b3b8030fd8c80b70fb5fa5b834e575c2", size = 1232140, upload-time = "2026-03-12T03:40:28.882Z" },
-    { url = "https://files.pythonhosted.org/packages/d5/da/e36e27c9cebc1311b7579210df6f1c86e50f2d7143ae4fcf8a5017dc8809/black-26.3.1-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:2d6bfaf7fd0993b420bed691f20f9492d53ce9a2bcccea4b797d34e947318a78", size = 1889234, upload-time = "2026-03-12T03:40:30.964Z" },
-    { url = "https://files.pythonhosted.org/packages/0e/7b/9871acf393f64a5fa33668c19350ca87177b181f44bb3d0c33b2d534f22c/black-26.3.1-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:f89f2ab047c76a9c03f78d0d66ca519e389519902fa27e7a91117ef7611c0568", size = 1720522, upload-time = "2026-03-12T03:40:32.346Z" },
-    { url = "https://files.pythonhosted.org/packages/03/87/e766c7f2e90c07fb7586cc787c9ae6462b1eedab390191f2b7fc7f6170a9/black-26.3.1-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:b07fc0dab849d24a80a29cfab8d8a19187d1c4685d8a5e6385a5ce323c1f015f", size = 1787824, upload-time = "2026-03-12T03:40:33.636Z" },
-    { url = "https://files.pythonhosted.org/packages/ac/94/2424338fb2d1875e9e83eed4c8e9c67f6905ec25afd826a911aea2b02535/black-26.3.1-cp314-cp314-win_amd64.whl", hash = "sha256:0126ae5b7c09957da2bdbd91a9ba1207453feada9e9fe51992848658c6c8e01c", size = 1445855, upload-time = "2026-03-12T03:40:35.442Z" },
-    { url = "https://files.pythonhosted.org/packages/86/43/0c3338bd928afb8ee7471f1a4eec3bdbe2245ccb4a646092a222e8669840/black-26.3.1-cp314-cp314-win_arm64.whl", hash = "sha256:92c0ec1f2cc149551a2b7b47efc32c866406b6891b0ee4625e95967c8f4acfb1", size = 1258109, upload-time = "2026-03-12T03:40:36.832Z" },
-    { url = "https://files.pythonhosted.org/packages/8e/0d/52d98722666d6fc6c3dd4c76df339501d6efd40e0ff95e6186a7b7f0befd/black-26.3.1-py3-none-any.whl", hash = "sha256:2bd5aa94fc267d38bb21a70d7410a89f1a1d318841855f698746f8e7f51acd1b", size = 207542, upload-time = "2026-03-12T03:36:01.668Z" },
-]
-
-[[package]]
 name = "cfgv"
 version = "3.5.0"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/4e/b5/721b8799b04bf9afe054a3899c6cf4e880fcf8563cc71c15610242490a0c/cfgv-3.5.0.tar.gz", hash = "sha256:d5b1034354820651caa73ede66a6294d6e95c1b00acc5e9b098e917404669132", size = 7334, upload-time = "2025-11-19T20:55:51.612Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/db/3c/33bac158f8ab7f89b2e59426d5fe2e4f63f7ed25df84c036890172b412b5/cfgv-3.5.0-py2.py3-none-any.whl", hash = "sha256:a8dc6b26ad22ff227d2634a65cb388215ce6cc96bbcc5cfde7641ae87e8dacc0", size = 7445, upload-time = "2025-11-19T20:55:50.744Z" },
-]
-
-[[package]]
-name = "click"
-version = "8.3.1"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "colorama", marker = "sys_platform == 'win32'" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/3d/fa/656b739db8587d7b5dfa22e22ed02566950fbfbcdc20311993483657a5c0/click-8.3.1.tar.gz", hash = "sha256:12ff4785d337a1bb490bb7e9c2b1ee5da3112e94a8622f26a6c77f5d2fc6842a", size = 295065, upload-time = "2025-11-15T20:45:42.706Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/98/78/01c019cdb5d6498122777c1a43056ebb3ebfeef2076d9d026bfe15583b2b/click-8.3.1-py3-none-any.whl", hash = "sha256:981153a64e25f12d547d3426c367a4857371575ee7ad18df2a6183ab0545b2a6", size = 108274, upload-time = "2025-11-15T20:45:41.139Z" },
 ]
 
 [[package]]
@@ -479,45 +423,6 @@ wheels = [
 ]
 
 [[package]]
-name = "pytokens"
-version = "0.4.1"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/b6/34/b4e015b99031667a7b960f888889c5bd34ef585c85e1cb56a594b92836ac/pytokens-0.4.1.tar.gz", hash = "sha256:292052fe80923aae2260c073f822ceba21f3872ced9a68bb7953b348e561179a", size = 23015, upload-time = "2026-01-30T01:03:45.924Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/42/24/f206113e05cb8ef51b3850e7ef88f20da6f4bf932190ceb48bd3da103e10/pytokens-0.4.1-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:2a44ed93ea23415c54f3face3b65ef2b844d96aeb3455b8a69b3df6beab6acc5", size = 161522, upload-time = "2026-01-30T01:02:50.393Z" },
-    { url = "https://files.pythonhosted.org/packages/d4/e9/06a6bf1b90c2ed81a9c7d2544232fe5d2891d1cd480e8a1809ca354a8eb2/pytokens-0.4.1-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:add8bf86b71a5d9fb5b89f023a80b791e04fba57960aa790cc6125f7f1d39dfe", size = 246945, upload-time = "2026-01-30T01:02:52.399Z" },
-    { url = "https://files.pythonhosted.org/packages/69/66/f6fb1007a4c3d8b682d5d65b7c1fb33257587a5f782647091e3408abe0b8/pytokens-0.4.1-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:670d286910b531c7b7e3c0b453fd8156f250adb140146d234a82219459b9640c", size = 259525, upload-time = "2026-01-30T01:02:53.737Z" },
-    { url = "https://files.pythonhosted.org/packages/04/92/086f89b4d622a18418bac74ab5db7f68cf0c21cf7cc92de6c7b919d76c88/pytokens-0.4.1-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:4e691d7f5186bd2842c14813f79f8884bb03f5995f0575272009982c5ac6c0f7", size = 262693, upload-time = "2026-01-30T01:02:54.871Z" },
-    { url = "https://files.pythonhosted.org/packages/b4/7b/8b31c347cf94a3f900bdde750b2e9131575a61fdb620d3d3c75832262137/pytokens-0.4.1-cp310-cp310-win_amd64.whl", hash = "sha256:27b83ad28825978742beef057bfe406ad6ed524b2d28c252c5de7b4a6dd48fa2", size = 103567, upload-time = "2026-01-30T01:02:56.414Z" },
-    { url = "https://files.pythonhosted.org/packages/3d/92/790ebe03f07b57e53b10884c329b9a1a308648fc083a6d4a39a10a28c8fc/pytokens-0.4.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:d70e77c55ae8380c91c0c18dea05951482e263982911fc7410b1ffd1dadd3440", size = 160864, upload-time = "2026-01-30T01:02:57.882Z" },
-    { url = "https://files.pythonhosted.org/packages/13/25/a4f555281d975bfdd1eba731450e2fe3a95870274da73fb12c40aeae7625/pytokens-0.4.1-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:4a58d057208cb9075c144950d789511220b07636dd2e4708d5645d24de666bdc", size = 248565, upload-time = "2026-01-30T01:02:59.912Z" },
-    { url = "https://files.pythonhosted.org/packages/17/50/bc0394b4ad5b1601be22fa43652173d47e4c9efbf0044c62e9a59b747c56/pytokens-0.4.1-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:b49750419d300e2b5a3813cf229d4e5a4c728dae470bcc89867a9ad6f25a722d", size = 260824, upload-time = "2026-01-30T01:03:01.471Z" },
-    { url = "https://files.pythonhosted.org/packages/4e/54/3e04f9d92a4be4fc6c80016bc396b923d2a6933ae94b5f557c939c460ee0/pytokens-0.4.1-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:d9907d61f15bf7261d7e775bd5d7ee4d2930e04424bab1972591918497623a16", size = 264075, upload-time = "2026-01-30T01:03:04.143Z" },
-    { url = "https://files.pythonhosted.org/packages/d1/1b/44b0326cb5470a4375f37988aea5d61b5cc52407143303015ebee94abfd6/pytokens-0.4.1-cp311-cp311-win_amd64.whl", hash = "sha256:ee44d0f85b803321710f9239f335aafe16553b39106384cef8e6de40cb4ef2f6", size = 103323, upload-time = "2026-01-30T01:03:05.412Z" },
-    { url = "https://files.pythonhosted.org/packages/41/5d/e44573011401fb82e9d51e97f1290ceb377800fb4eed650b96f4753b499c/pytokens-0.4.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:140709331e846b728475786df8aeb27d24f48cbcf7bcd449f8de75cae7a45083", size = 160663, upload-time = "2026-01-30T01:03:06.473Z" },
-    { url = "https://files.pythonhosted.org/packages/f0/e6/5bbc3019f8e6f21d09c41f8b8654536117e5e211a85d89212d59cbdab381/pytokens-0.4.1-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6d6c4268598f762bc8e91f5dbf2ab2f61f7b95bdc07953b602db879b3c8c18e1", size = 255626, upload-time = "2026-01-30T01:03:08.177Z" },
-    { url = "https://files.pythonhosted.org/packages/bf/3c/2d5297d82286f6f3d92770289fd439956b201c0a4fc7e72efb9b2293758e/pytokens-0.4.1-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:24afde1f53d95348b5a0eb19488661147285ca4dd7ed752bbc3e1c6242a304d1", size = 269779, upload-time = "2026-01-30T01:03:09.756Z" },
-    { url = "https://files.pythonhosted.org/packages/20/01/7436e9ad693cebda0551203e0bf28f7669976c60ad07d6402098208476de/pytokens-0.4.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:5ad948d085ed6c16413eb5fec6b3e02fa00dc29a2534f088d3302c47eb59adf9", size = 268076, upload-time = "2026-01-30T01:03:10.957Z" },
-    { url = "https://files.pythonhosted.org/packages/2e/df/533c82a3c752ba13ae7ef238b7f8cdd272cf1475f03c63ac6cf3fcfb00b6/pytokens-0.4.1-cp312-cp312-win_amd64.whl", hash = "sha256:3f901fe783e06e48e8cbdc82d631fca8f118333798193e026a50ce1b3757ea68", size = 103552, upload-time = "2026-01-30T01:03:12.066Z" },
-    { url = "https://files.pythonhosted.org/packages/cb/dc/08b1a080372afda3cceb4f3c0a7ba2bde9d6a5241f1edb02a22a019ee147/pytokens-0.4.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:8bdb9d0ce90cbf99c525e75a2fa415144fd570a1ba987380190e8b786bc6ef9b", size = 160720, upload-time = "2026-01-30T01:03:13.843Z" },
-    { url = "https://files.pythonhosted.org/packages/64/0c/41ea22205da480837a700e395507e6a24425151dfb7ead73343d6e2d7ffe/pytokens-0.4.1-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:5502408cab1cb18e128570f8d598981c68a50d0cbd7c61312a90507cd3a1276f", size = 254204, upload-time = "2026-01-30T01:03:14.886Z" },
-    { url = "https://files.pythonhosted.org/packages/e0/d2/afe5c7f8607018beb99971489dbb846508f1b8f351fcefc225fcf4b2adc0/pytokens-0.4.1-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:29d1d8fb1030af4d231789959f21821ab6325e463f0503a61d204343c9b355d1", size = 268423, upload-time = "2026-01-30T01:03:15.936Z" },
-    { url = "https://files.pythonhosted.org/packages/68/d4/00ffdbd370410c04e9591da9220a68dc1693ef7499173eb3e30d06e05ed1/pytokens-0.4.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:970b08dd6b86058b6dc07efe9e98414f5102974716232d10f32ff39701e841c4", size = 266859, upload-time = "2026-01-30T01:03:17.458Z" },
-    { url = "https://files.pythonhosted.org/packages/a7/c9/c3161313b4ca0c601eeefabd3d3b576edaa9afdefd32da97210700e47652/pytokens-0.4.1-cp313-cp313-win_amd64.whl", hash = "sha256:9bd7d7f544d362576be74f9d5901a22f317efc20046efe2034dced238cbbfe78", size = 103520, upload-time = "2026-01-30T01:03:18.652Z" },
-    { url = "https://files.pythonhosted.org/packages/8f/a7/b470f672e6fc5fee0a01d9e75005a0e617e162381974213a945fcd274843/pytokens-0.4.1-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:4a14d5f5fc78ce85e426aa159489e2d5961acf0e47575e08f35584009178e321", size = 160821, upload-time = "2026-01-30T01:03:19.684Z" },
-    { url = "https://files.pythonhosted.org/packages/80/98/e83a36fe8d170c911f864bfded690d2542bfcfacb9c649d11a9e6eb9dc41/pytokens-0.4.1-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:97f50fd18543be72da51dd505e2ed20d2228c74e0464e4262e4899797803d7fa", size = 254263, upload-time = "2026-01-30T01:03:20.834Z" },
-    { url = "https://files.pythonhosted.org/packages/0f/95/70d7041273890f9f97a24234c00b746e8da86df462620194cef1d411ddeb/pytokens-0.4.1-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:dc74c035f9bfca0255c1af77ddd2d6ae8419012805453e4b0e7513e17904545d", size = 268071, upload-time = "2026-01-30T01:03:21.888Z" },
-    { url = "https://files.pythonhosted.org/packages/da/79/76e6d09ae19c99404656d7db9c35dfd20f2086f3eb6ecb496b5b31163bad/pytokens-0.4.1-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:f66a6bbe741bd431f6d741e617e0f39ec7257ca1f89089593479347cc4d13324", size = 271716, upload-time = "2026-01-30T01:03:23.633Z" },
-    { url = "https://files.pythonhosted.org/packages/79/37/482e55fa1602e0a7ff012661d8c946bafdc05e480ea5a32f4f7e336d4aa9/pytokens-0.4.1-cp314-cp314-win_amd64.whl", hash = "sha256:b35d7e5ad269804f6697727702da3c517bb8a5228afa450ab0fa787732055fc9", size = 104539, upload-time = "2026-01-30T01:03:24.788Z" },
-    { url = "https://files.pythonhosted.org/packages/30/e8/20e7db907c23f3d63b0be3b8a4fd1927f6da2395f5bcc7f72242bb963dfe/pytokens-0.4.1-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:8fcb9ba3709ff77e77f1c7022ff11d13553f3c30299a9fe246a166903e9091eb", size = 168474, upload-time = "2026-01-30T01:03:26.428Z" },
-    { url = "https://files.pythonhosted.org/packages/d6/81/88a95ee9fafdd8f5f3452107748fd04c24930d500b9aba9738f3ade642cc/pytokens-0.4.1-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:79fc6b8699564e1f9b521582c35435f1bd32dd06822322ec44afdeba666d8cb3", size = 290473, upload-time = "2026-01-30T01:03:27.415Z" },
-    { url = "https://files.pythonhosted.org/packages/cf/35/3aa899645e29b6375b4aed9f8d21df219e7c958c4c186b465e42ee0a06bf/pytokens-0.4.1-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:d31b97b3de0f61571a124a00ffe9a81fb9939146c122c11060725bd5aea79975", size = 303485, upload-time = "2026-01-30T01:03:28.558Z" },
-    { url = "https://files.pythonhosted.org/packages/52/a0/07907b6ff512674d9b201859f7d212298c44933633c946703a20c25e9d81/pytokens-0.4.1-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:967cf6e3fd4adf7de8fc73cd3043754ae79c36475c1c11d514fc72cf5490094a", size = 306698, upload-time = "2026-01-30T01:03:29.653Z" },
-    { url = "https://files.pythonhosted.org/packages/39/2a/cbbf9250020a4a8dd53ba83a46c097b69e5eb49dd14e708f496f548c6612/pytokens-0.4.1-cp314-cp314t-win_amd64.whl", hash = "sha256:584c80c24b078eec1e227079d56dc22ff755e0ba8654d8383b2c549107528918", size = 116287, upload-time = "2026-01-30T01:03:30.912Z" },
-    { url = "https://files.pythonhosted.org/packages/c6/78/397db326746f0a342855b81216ae1f0a32965deccfd7c830a2dbc66d2483/pytokens-0.4.1-py3-none-any.whl", hash = "sha256:26cef14744a8385f35d0e095dc8b3a7583f6c953c2e3d269c7f82484bf5ad2de", size = 13729, upload-time = "2026-01-30T01:03:45.029Z" },
-]
-
-[[package]]
 name = "pyyaml"
 version = "6.0.3"
 source = { registry = "https://pypi.org/simple" }
@@ -592,7 +497,6 @@ dependencies = [
 
 [package.optional-dependencies]
 dev = [
-    { name = "black" },
     { name = "coverage" },
     { name = "mypy" },
     { name = "pre-commit" },
@@ -602,7 +506,6 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "black", marker = "extra == 'dev'", specifier = ">=23.1.0" },
     { name = "coverage", marker = "extra == 'dev'", specifier = ">=6.4" },
     { name = "mypy", marker = "extra == 'dev'", specifier = ">=1.0" },
     { name = "pathspec", specifier = ">=0.12.1" },


### PR DESCRIPTION
## Summary
This PR refactors RepoGPT analysis/runtime wiring, hardens collector and tree utility behavior, and broadens coverage for parser/projector edge cases while keeping CLI/MCP parity stable.

## Scope
- Migrates local validation/tooling to uv and updates CI/pre-commit/mypy formatting command flow.
- Centralizes analysis runtime construction shared by CLI and MCP entrypoints.
- Hardens file collection/tree utilities with safer traversal and benchmark helper alignment.
- Expands unit coverage for parser and projector edge conditions.
- Aligns MCP integration test assertions with CLI output contracts.
- Updates documentation for architecture, usage, and roadmap context.
- Removes legacy empty test artifact and ignores local `.codex` metadata.

## Validation
- `UV_CACHE_DIR=/tmp/uv_cache uv run ruff format --check .`
- `UV_CACHE_DIR=/tmp/uv_cache uv run ruff check .`
- `UV_CACHE_DIR=/tmp/uv_cache uv run mypy src tests`
- `UV_CACHE_DIR=/tmp/uv_cache uv run pytest -q`

## Commit sequence
1. `chore(repogpt): migrate validation flow to uv`
2. `refactor(repogpt): centralize analyze runtime`
3. `refactor(repogpt): harden collector and tree utilities`
4. `test(repogpt): add parser and projector edge tests`
5. `test(repogpt): align MCP payload parity with CLI`
6. `docs(repogpt): refresh docs and usage contracts`
7. `chore(repogpt): remove empty legacy models test`
8. `chore(repogpt): ignore local .codex artifacts`
