### PR TITLE
Harden RepoGPT contracts, MCP parity, and collector traversal

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ Without `--fail-fast`, runs return `0` or `2`, never `1`.
 
 ## Collection and skip rules
 
-RepoGPT collects files with a deterministic `rglob()` walk plus stable relative-path ordering. The public artifact contains parsed files and parse failures; skipped files remain internal implementation detail.
+RepoGPT collects files with deterministic pruned traversal plus stable relative-path ordering. The public artifact contains parsed files and parse failures; skipped files remain internal implementation detail.
 
 Built-in ignores are always excluded:
 
@@ -95,6 +95,7 @@ Built-in ignores are always excluded:
 Additional collection rules:
 
 - `.repogptignore` uses gitignore-style matching via `pathspec`
+- ignored directories are pruned before descent and are not expanded into per-file skips
 - test paths are skipped unless `--include-tests` is set
 - files larger than `2_000_000` bytes are skipped
 - symlinks are skipped

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -204,10 +204,11 @@ It does not claim end-to-end task quality, production relevance quality, or agen
 
 Collection behavior is deterministic and currently includes:
 
-- `rglob()` over the repository root
+- deterministic pruned traversal over the repository root
 - canonical relative-path sort
 - built-in ignore directories/files
 - optional `.repogptignore`
+- silent pruning for ignored directories before descent
 - test exclusion by default
 - file-size guard
 - binary-file detection

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,7 +38,8 @@ dev = [
   "ruff>=0.0.291", 
   "mypy>=1.0",
   "pre-commit>=2.20",
-  "coverage>=6.4"
+  "coverage>=6.4",
+  "jsonschema>=4.0"
 ]
 
 

--- a/schemas/ast-v1.schema.json
+++ b/schemas/ast-v1.schema.json
@@ -1,0 +1,124 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://repogpt.local/schemas/ast-v1.schema.json",
+  "title": "RepoGPT AST v1",
+  "anyOf": [
+    { "$ref": "#/$defs/envelope" },
+    { "$ref": "#/$defs/nodeRecord" },
+    { "$ref": "#/$defs/failureRecord" },
+    { "$ref": "#/$defs/summaryRecord" }
+  ],
+  "$defs": {
+    "fileDigest": {
+      "type": "object",
+      "required": ["size", "sha256"],
+      "properties": {
+        "size": { "type": "integer", "minimum": 0 },
+        "sha256": { "type": "string", "pattern": "^[a-f0-9]{64}$" }
+      },
+      "additionalProperties": true
+    },
+    "stats": {
+      "type": "object",
+      "required": ["total_files", "ok_files", "failed_files", "emitted_records"],
+      "properties": {
+        "total_files": { "type": "integer", "minimum": 0 },
+        "ok_files": { "type": "integer", "minimum": 0 },
+        "failed_files": { "type": "integer", "minimum": 0 },
+        "emitted_records": { "type": "integer", "minimum": 0 }
+      },
+      "additionalProperties": true
+    },
+    "nodeBase": {
+      "type": "object",
+      "required": [
+        "id",
+        "type",
+        "language",
+        "path",
+        "start_line",
+        "end_line",
+        "comments",
+        "tags",
+        "dependencies",
+        "parent_id",
+        "attributes",
+        "metrics"
+      ],
+      "properties": {
+        "id": { "type": "string", "minLength": 1 },
+        "type": { "type": "string", "minLength": 1 },
+        "name": { "type": ["string", "null"] },
+        "language": { "type": ["string", "null"] },
+        "path": { "type": ["string", "null"] },
+        "start_line": { "type": ["integer", "null"], "minimum": 1 },
+        "end_line": { "type": ["integer", "null"], "minimum": 1 },
+        "docstring": { "type": ["string", "null"] },
+        "comments": { "type": "array", "items": { "type": "object" } },
+        "tags": { "type": "array", "items": { "type": "string" } },
+        "dependencies": { "type": "array" },
+        "parent_id": { "type": ["string", "null"] },
+        "children": { "type": "array" },
+        "attributes": { "type": "object" },
+        "metrics": { "type": "object" }
+      },
+      "additionalProperties": true
+    },
+    "nodeRecord": {
+      "allOf": [
+        { "$ref": "#/$defs/nodeBase" },
+        {
+          "type": "object",
+          "required": ["record_type", "schema_version", "file"],
+          "properties": {
+            "record_type": { "const": "node" },
+            "schema_version": { "const": "1" },
+            "file": { "$ref": "#/$defs/fileDigest" }
+          }
+        }
+      ]
+    },
+    "failureRecord": {
+      "type": "object",
+      "required": ["record_type", "schema_version", "path", "language", "error", "file"],
+      "properties": {
+        "record_type": { "const": "failure" },
+        "schema_version": { "const": "1" },
+        "path": { "type": "string" },
+        "language": { "type": "string" },
+        "error": { "type": "string" },
+        "file": { "$ref": "#/$defs/fileDigest" }
+      },
+      "additionalProperties": true
+    },
+    "summaryRecord": {
+      "type": "object",
+      "required": ["record_type", "schema_version", "repo_root", "stats"],
+      "properties": {
+        "record_type": { "const": "summary" },
+        "schema_version": { "const": "1" },
+        "repo_root": { "type": "string" },
+        "stats": { "$ref": "#/$defs/stats" }
+      },
+      "additionalProperties": true
+    },
+    "envelope": {
+      "type": "object",
+      "required": ["schema_version", "repo_root", "stats", "failures", "records"],
+      "properties": {
+        "schema_version": { "const": "1" },
+        "repo_root": { "type": "string" },
+        "stats": { "$ref": "#/$defs/stats" },
+        "failures": {
+          "type": "array",
+          "items": { "$ref": "#/$defs/failureRecord" }
+        },
+        "records": {
+          "type": "array",
+          "items": { "$ref": "#/$defs/nodeRecord" }
+        }
+      },
+      "additionalProperties": false
+    }
+  }
+}

--- a/schemas/code-units-v4.schema.json
+++ b/schemas/code-units-v4.schema.json
@@ -1,0 +1,130 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://repogpt.local/schemas/code-units-v4.schema.json",
+  "title": "RepoGPT Code Units v4",
+  "type": "object",
+  "required": [
+    "schema_version",
+    "kind",
+    "repo_key",
+    "snapshot_id",
+    "scope",
+    "replace_scope",
+    "stats",
+    "failures",
+    "documents"
+  ],
+  "properties": {
+    "schema_version": { "const": "4" },
+    "kind": { "const": "code-units" },
+    "repo_key": { "type": "string", "minLength": 1 },
+    "snapshot_id": { "type": "string", "minLength": 1 },
+    "scope": { "type": "string", "minLength": 1 },
+    "replace_scope": { "type": "boolean" },
+    "stats": { "$ref": "#/$defs/stats" },
+    "failures": {
+      "type": "array",
+      "items": { "$ref": "#/$defs/failureRecord" }
+    },
+    "documents": {
+      "type": "array",
+      "items": { "$ref": "#/$defs/document" }
+    }
+  },
+  "additionalProperties": false,
+  "$defs": {
+    "fileDigest": {
+      "type": "object",
+      "required": ["size", "sha256"],
+      "properties": {
+        "size": { "type": "integer", "minimum": 0 },
+        "sha256": { "type": "string", "pattern": "^[a-f0-9]{64}$" }
+      },
+      "additionalProperties": true
+    },
+    "stats": {
+      "type": "object",
+      "required": ["total_files", "ok_files", "failed_files", "emitted_documents"],
+      "properties": {
+        "total_files": { "type": "integer", "minimum": 0 },
+        "ok_files": { "type": "integer", "minimum": 0 },
+        "failed_files": { "type": "integer", "minimum": 0 },
+        "emitted_documents": { "type": "integer", "minimum": 0 }
+      },
+      "additionalProperties": true
+    },
+    "failureRecord": {
+      "type": "object",
+      "required": ["record_type", "schema_version", "path", "language", "error", "file"],
+      "properties": {
+        "record_type": { "const": "failure" },
+        "schema_version": { "const": "4" },
+        "path": { "type": "string" },
+        "language": { "type": "string" },
+        "error": { "type": "string" },
+        "file": { "$ref": "#/$defs/fileDigest" }
+      },
+      "additionalProperties": true
+    },
+    "document": {
+      "type": "object",
+      "required": [
+        "external_id",
+        "source_id",
+        "repo_key",
+        "scope",
+        "snapshot_id",
+        "path",
+        "language",
+        "unit_type",
+        "unit_level",
+        "symbol",
+        "qualified_name",
+        "container_id",
+        "depth",
+        "ancestor_path",
+        "start_line",
+        "end_line",
+        "content",
+        "content_hash",
+        "docstring_present",
+        "has_children",
+        "metadata"
+      ],
+      "properties": {
+        "external_id": { "type": "string", "minLength": 1 },
+        "source_id": { "type": "string", "minLength": 1 },
+        "repo_key": { "type": "string", "minLength": 1 },
+        "scope": { "type": "string", "minLength": 1 },
+        "snapshot_id": { "type": "string", "minLength": 1 },
+        "path": { "type": "string", "minLength": 1 },
+        "language": { "type": ["string", "null"] },
+        "unit_type": { "type": "string", "minLength": 1 },
+        "unit_level": { "enum": ["container", "symbol"] },
+        "symbol": { "type": ["string", "null"] },
+        "qualified_name": { "type": "string", "minLength": 1 },
+        "container_id": { "type": "string", "minLength": 1 },
+        "depth": { "type": "integer", "minimum": 0 },
+        "ancestor_path": { "type": "array", "items": { "type": "string" } },
+        "start_line": { "type": ["integer", "null"], "minimum": 1 },
+        "end_line": { "type": ["integer", "null"], "minimum": 1 },
+        "content": { "type": "string" },
+        "content_hash": { "type": "string", "pattern": "^[a-f0-9]{64}$" },
+        "docstring_present": { "type": "boolean" },
+        "has_children": { "type": "boolean" },
+        "metadata": {
+          "type": "object",
+          "required": ["file", "tags", "attributes", "dependencies"],
+          "properties": {
+            "file": { "$ref": "#/$defs/fileDigest" },
+            "tags": { "type": "array", "items": { "type": "string" } },
+            "attributes": { "type": "object" },
+            "dependencies": { "type": "array" }
+          },
+          "additionalProperties": true
+        }
+      },
+      "additionalProperties": true
+    }
+  }
+}

--- a/src/repogpt/__init__.py
+++ b/src/repogpt/__init__.py
@@ -1,7 +1,11 @@
 from __future__ import annotations
 
 import logging
+from importlib.metadata import PackageNotFoundError, version
 
-__version__ = "0.8.3"
+try:
+    __version__ = version("repogpt")
+except PackageNotFoundError:  # pragma: no cover - source tree without package metadata
+    __version__ = "0.0.0+local"
 
 logging.getLogger(__name__).addHandler(logging.NullHandler())

--- a/src/repogpt/adapters/fs/collector.py
+++ b/src/repogpt/adapters/fs/collector.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import os
 from pathlib import Path
 
 import pathspec
@@ -40,7 +41,7 @@ def load_pathspec(repo_root: Path) -> pathspec.PathSpec | None:
                 lines = [
                     line for line in handle if line.strip() and not line.strip().startswith("#")
                 ]
-            return pathspec.PathSpec.from_lines("gitignore", lines)
+            return pathspec.GitIgnoreSpec.from_lines(lines)
     except (OSError, ValueError, UnicodeError):
         logger.warning("failed to read repogptignore", path=str(ignore_file))
     return None
@@ -55,7 +56,7 @@ def ignore_reason(p: Path, repo_root: Path, spec: pathspec.PathSpec | None = Non
             return "symlink"
     except OSError:
         return "symlink_error"
-    if spec and spec.match_file(str(rel)):
+    if spec and _matches_pathspec(spec, rel, is_dir=p.is_dir()):
         return "repogptignore"
     return None
 
@@ -74,10 +75,7 @@ class DefaultCollector(CollectorPort):
         spec = load_pathspec(repo_root)
         files: list[CollectedFile] = []
         skipped: list[SkippedFile] = []
-        paths = sorted(
-            repo_root.rglob("*"),
-            key=lambda path: path.relative_to(repo_root).as_posix(),
-        )
+        paths = self._candidate_files(repo_root=repo_root, spec=spec)
         for path in paths:
             relative_path = path.relative_to(repo_root).as_posix()
             reason = ignore_reason(path, repo_root, spec)
@@ -153,6 +151,34 @@ class DefaultCollector(CollectorPort):
             )
         return files, skipped
 
+    def _candidate_files(
+        self,
+        *,
+        repo_root: Path,
+        spec: pathspec.PathSpec | None,
+    ) -> list[Path]:
+        candidates: list[Path] = []
+
+        def onerror(error: OSError) -> None:
+            logger.warning("failed to walk path", error=str(error))
+
+        for dirpath, dirnames, filenames in os.walk(repo_root, topdown=True, onerror=onerror):
+            current_dir = Path(dirpath)
+            kept_dirs: list[str] = []
+            for dirname in sorted(dirnames):
+                path = current_dir / dirname
+                if ignore_reason(path, repo_root, spec) is None:
+                    kept_dirs.append(dirname)
+            dirnames[:] = kept_dirs
+
+            for filename in sorted(filenames):
+                candidates.append(current_dir / filename)
+
+        return sorted(
+            candidates,
+            key=lambda path: path.relative_to(repo_root).as_posix(),
+        )
+
     def _is_test_path(self, path: Path, repo_root: Path) -> bool:
         rel_parts = path.relative_to(repo_root).parts
         return "tests" in rel_parts or path.name.startswith(("test_", "test-"))
@@ -181,3 +207,10 @@ class DefaultCollector(CollectorPort):
                     reason=f"{reason}_is_file_error",
                 )
             )
+
+
+def _matches_pathspec(spec: pathspec.PathSpec, rel: Path, *, is_dir: bool) -> bool:
+    relative_path = rel.as_posix()
+    if spec.match_file(relative_path):
+        return True
+    return is_dir and spec.match_file(f"{relative_path}/")

--- a/src/repogpt/app/cli.py
+++ b/src/repogpt/app/cli.py
@@ -10,6 +10,7 @@ import structlog
 from repogpt.adapters.parsers.registry import StaticParserRegistry
 from repogpt.adapters.writers.artifact_writer import ArtifactWriter
 from repogpt.application.exit_codes import exit_code_for_result
+from repogpt.application.languages import UnsupportedLanguagesError, parse_cli_languages
 from repogpt.domain.analysis import AnalysisRequest, OutputTarget
 from repogpt.domain.errors import InvalidRepoError
 from repogpt.runtime import build_analyze_repo
@@ -23,14 +24,6 @@ def _configure_logging(level: str) -> None:
         wrapper_class=structlog.make_filtering_bound_logger(LEVELS[level]),
         logger_factory=structlog.PrintLoggerFactory(file=sys.stderr),
     )
-
-
-def _parse_languages_arg(raw_languages: str | None) -> list[str] | None:
-    if raw_languages is None:
-        return None
-    if raw_languages == "":
-        return []
-    return [lang for lang in (s.strip().lower() for s in raw_languages.split(",")) if lang]
 
 
 def main() -> int:  # noqa: D401
@@ -55,16 +48,13 @@ def main() -> int:  # noqa: D401
     log = structlog.get_logger()
     registry = StaticParserRegistry()
 
-    langs = _parse_languages_arg(args.languages)
-    if langs is not None:
-        unsupported = sorted(set(langs) - registry.supported_extensions())
-        if unsupported:
-            parser.error(
-                "unsupported languages: "
-                + ", ".join(unsupported)
-                + "; supported: "
-                + ", ".join(sorted(registry.supported_extensions()))
-            )
+    try:
+        langs = parse_cli_languages(
+            args.languages,
+            supported_extensions=registry.supported_extensions(),
+        )
+    except UnsupportedLanguagesError as exc:
+        parser.error(exc.message)
     if args.emit == "code-units" and args.format != "json":
         parser.error("--emit code-units only supports --format json")
     to_stdout = args.stdout or (args.output and Path(args.output).as_posix() == "/dev/stdout")

--- a/src/repogpt/application/languages.py
+++ b/src/repogpt/application/languages.py
@@ -1,0 +1,52 @@
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+
+class UnsupportedLanguagesError(ValueError):
+    def __init__(self, *, unsupported: list[str], supported: set[str]) -> None:
+        self.unsupported = unsupported
+        self.supported = supported
+        super().__init__(self.message)
+
+    @property
+    def message(self) -> str:
+        return (
+            "unsupported languages: "
+            + ", ".join(self.unsupported)
+            + "; supported: "
+            + ", ".join(sorted(self.supported))
+        )
+
+
+def parse_cli_languages(
+    raw_languages: str | None,
+    *,
+    supported_extensions: set[str],
+) -> list[str] | None:
+    if raw_languages is None:
+        return None
+    if raw_languages == "":
+        return []
+    return normalize_language_filter(
+        raw_languages.split(","),
+        supported_extensions=supported_extensions,
+    )
+
+
+def normalize_language_filter(
+    languages: Sequence[str] | None,
+    *,
+    supported_extensions: set[str],
+) -> list[str] | None:
+    if languages is None:
+        return None
+
+    normalized = [language.strip().lower() for language in languages if language.strip()]
+    unsupported = sorted(set(normalized) - supported_extensions)
+    if unsupported:
+        raise UnsupportedLanguagesError(
+            unsupported=unsupported,
+            supported=supported_extensions,
+        )
+    return normalized

--- a/src/repogpt/mcp_server.py
+++ b/src/repogpt/mcp_server.py
@@ -16,6 +16,8 @@ from repogpt.domain.analysis import (
     OutputTarget,
 )
 from repogpt.application.exit_codes import exit_code_for_result
+from repogpt.application.languages import normalize_language_filter
+from repogpt.adapters.parsers.registry import StaticParserRegistry
 from repogpt.runtime import build_analyze_repo
 from repogpt.utils.retrieval_profiles import compare_profiles
 
@@ -46,10 +48,14 @@ def _build_request(
     flatten: Literal["node", "file"] | None = None,
     fmt: Literal["json", "ndjson"] = "json",
 ) -> AnalysisRequest:
+    registry = StaticParserRegistry()
     return AnalysisRequest(
         repo_root=Path(repo_path).resolve(),
         include_tests=include_tests,
-        supported_languages=languages,
+        supported_languages=normalize_language_filter(
+            languages,
+            supported_extensions=registry.supported_extensions(),
+        ),
         projection="code_units" if emit == "code-units" else "ast",
         format=fmt,
         flatten_kind=flatten or "node",

--- a/src/repogpt/utils/file_utils.py
+++ b/src/repogpt/utils/file_utils.py
@@ -1,5 +1,3 @@
-# repogpt/utils/file_utils.py
-
 import hashlib
 from pathlib import Path
 
@@ -7,20 +5,11 @@ import structlog
 
 logger = structlog.get_logger(__name__)
 
-CHUNK_SIZE = 8192  # Leer archivos en bloques de 8KB para hashing
+CHUNK_SIZE = 8192
 
 
 def calculate_file_hash(file_path: Path, algorithm: str = "sha256") -> str | None:
-    """
-    Calcula el hash de un archivo usando el algoritmo especificado.
-
-    Args:
-        file_path: Ruta al archivo.
-        algorithm: Algoritmo de hash a usar (ej. 'sha256', 'md5').
-
-    Returns:
-        El hash en formato hexadecimal como string, o None si ocurre un error.
-    """
+    """Calculate a file hash, returning None when the file cannot be read."""
     try:
         hasher = hashlib.new(algorithm)
         with file_path.open("rb") as f:
@@ -42,41 +31,24 @@ def calculate_file_hash(file_path: Path, algorithm: str = "sha256") -> str | Non
 
 
 def is_likely_binary(file_path: Path, check_bytes: int = 1024) -> bool:
-    """
-    Intenta determinar si un archivo es probablemente binario.
-
-    Actualmente usa una heurística simple: la presencia de un byte NULL
-    dentro de los primeros 'check_bytes'.
-
-    Args:
-        file_path: Ruta al archivo.
-        check_bytes: Número de bytes iniciales a revisar.
-
-    Returns:
-        True si el archivo parece binario, False en caso contrario o si hay error.
-    """
+    """Return True when a file looks binary based on an initial byte sample."""
     try:
         with file_path.open("rb") as f:
             chunk = f.read(check_bytes)
             if b"\x00" in chunk:
                 logger.debug("detected null byte", path=str(file_path))
                 return True
-            # Podríamos añadir más heurísticas aquí si fuera necesario
-            # Por ejemplo, buscar un alto porcentaje de caracteres no imprimibles.
     except FileNotFoundError:
         logger.warning("file not found while checking binary", path=str(file_path))
-        return False  # No se puede determinar, asumir no binario por seguridad
+        return False
     except PermissionError:
         logger.warning("permission denied while checking binary", path=str(file_path))
-        return False  # Asumir no binario
+        return False
     except OSError as e:
         logger.warning("os error while checking binary", path=str(file_path), error=str(e))
-        return False  # Asumir no binario
+        return False
     except Exception as e:
         logger.warning("unexpected error while checking binary", path=str(file_path), error=str(e))
-        return False  # Asumir no binario
+        return False
 
     return False
-
-
-# Podrías añadir aquí otras utilidades relacionadas con archivos si las necesitas.

--- a/src/repogpt/utils/text_processing.py
+++ b/src/repogpt/utils/text_processing.py
@@ -1,5 +1,3 @@
-# repogpt/utils/text_processing.py
-
 import bisect
 import io
 import re
@@ -12,16 +10,12 @@ logger = structlog.get_logger(__name__)
 
 
 def count_blank_lines(text: str) -> int:
-    """Cuenta líneas completamente en blanco."""
+    """Count fully blank lines."""
     return sum(1 for line in text.splitlines() if not line.strip())
 
 
 def extract_comments(content: str, language: str = "python") -> list[dict[str, Any]]:
-    """
-    Extrae comentarios con línea para distintos lenguajes.
-
-    Devuelve: [{"text": ..., "line": ...}]
-    """
+    """Extract comments with their starting line number."""
     comments = []
     if language == "python":
         try:
@@ -40,8 +34,7 @@ def extract_comments(content: str, language: str = "python") -> list[dict[str, A
                 error=str(exc),
             )
     elif language == "markdown":
-        # Searc <!-- ... -->  HTML comments
-        # Pre-compute \n pos only one time: O(N) (upgrade from O(N×M))
+        # Pre-compute newline offsets once to avoid O(N*M) line counting.
         newline_offsets = [i for i, ch in enumerate(content) if ch == "\n"]
         for match in re.finditer(r"<!--(.*?)-->", content, re.DOTALL):
             line = bisect.bisect_left(newline_offsets, match.start()) + 1
@@ -51,20 +44,11 @@ def extract_comments(content: str, language: str = "python") -> list[dict[str, A
                     "line": line,
                 }
             )
-    # Add langs here
     return comments
 
 
 def extract_todos_fixmes(comments: list[dict[str, Any]]) -> tuple[list[str], list[str]]:
-    """
-    Extrae TODOs y FIXMEs de una lista de comentarios.
-
-    Args:
-        comments: Lista de diccionarios con comentarios extraídos
-
-    Returns:
-        Tupla con dos listas: (todos, fixmes)
-    """
+    """Extract TODO and FIXME comment texts."""
     todos: list[str] = []
     fixmes: list[str] = []
     for c in comments:

--- a/src/repogpt/utils/tree_utils.py
+++ b/src/repogpt/utils/tree_utils.py
@@ -44,5 +44,5 @@ def iter_nodes(root: CodeNode) -> list[CodeNode]:
 
 
 def all_comments(root: CodeNode) -> list[dict[str, Any]]:
-    """Devuelve todos los comentarios de todos los nodos."""
+    """Return all comments from every node in the tree."""
     return [dict(c) for n in iter_nodes(root) for c in n.comments]

--- a/tests/integration/test_artifact_schemas.py
+++ b/tests/integration/test_artifact_schemas.py
@@ -1,0 +1,45 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any, cast
+
+from jsonschema import Draft202012Validator
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+GOLDEN_ROOT = REPO_ROOT / "tests" / "golden"
+SCHEMA_ROOT = REPO_ROOT / "schemas"
+
+
+def _load_json(path: Path) -> dict[str, Any]:
+    return cast(dict[str, Any], json.loads(path.read_text(encoding="utf-8")))
+
+
+def _validator(schema_name: str) -> Draft202012Validator:
+    schema = _load_json(SCHEMA_ROOT / schema_name)
+    Draft202012Validator.check_schema(schema)
+    return Draft202012Validator(schema)
+
+
+def test_ast_json_golden_matches_public_schema() -> None:
+    validator = _validator("ast-v1.schema.json")
+    validator.validate(_load_json(GOLDEN_ROOT / "cli_fixture_json.json"))
+
+
+def test_ast_ndjson_golden_records_match_public_schema() -> None:
+    validator = _validator("ast-v1.schema.json")
+    records = [
+        json.loads(line)
+        for line in (GOLDEN_ROOT / "cli_fixture_ndjson.ndjson")
+        .read_text(encoding="utf-8")
+        .splitlines()
+        if line.strip()
+    ]
+
+    for record in records:
+        validator.validate(record)
+
+
+def test_code_units_json_golden_matches_public_schema() -> None:
+    validator = _validator("code-units-v4.schema.json")
+    validator.validate(_load_json(GOLDEN_ROOT / "cli_fixture_code_units.json"))

--- a/tests/integration/test_mcp_server.py
+++ b/tests/integration/test_mcp_server.py
@@ -7,6 +7,7 @@ import sys
 from pathlib import Path
 from typing import Any, cast
 
+import repogpt
 from repogpt.mcp_server import handle_request
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
@@ -93,6 +94,8 @@ def _assert_payloads_equivalent(
 def test_mcp_initialize_and_list_tools() -> None:
     initialize = handle_request({"jsonrpc": "2.0", "id": 1, "method": "initialize", "params": {}})
     assert initialize["result"]["serverInfo"]["name"] == "repogpt"
+    assert initialize["result"]["serverInfo"]["version"] == repogpt.__version__
+    assert repogpt.__version__
 
     listed = handle_request({"jsonrpc": "2.0", "id": 2, "method": "tools/list", "params": {}})
     names = {tool["name"] for tool in listed["result"]["tools"]}
@@ -128,6 +131,73 @@ def test_mcp_emit_code_units_matches_cli_output() -> None:
     payload = _extract_content_text(response)
     assert payload["exit_code"] == 2
     assert payload["artifact"] == cli_payload
+
+
+def test_mcp_language_filter_matches_cli_normalization() -> None:
+    cli_run = _run(["--stdout", "--format", "json", "--languages", "py"], CLI_FIXTURE)
+    assert cli_run.returncode == 2
+    cli_payload = json.loads(cli_run.stdout)
+
+    response = handle_request(
+        {
+            "jsonrpc": "2.0",
+            "id": 31,
+            "method": "tools/call",
+            "params": {
+                "name": "repogpt_emit_ast",
+                "arguments": {
+                    "repo_path": str(CLI_FIXTURE),
+                    "languages": [" PY "],
+                },
+            },
+        }
+    )
+
+    payload = _extract_content_text(response)
+    assert payload["exit_code"] == 2
+    assert payload["artifact"] == cli_payload
+
+
+def test_mcp_rejects_unsupported_language_like_cli() -> None:
+    response = handle_request(
+        {
+            "jsonrpc": "2.0",
+            "id": 32,
+            "method": "tools/call",
+            "params": {
+                "name": "repogpt_emit_ast",
+                "arguments": {
+                    "repo_path": str(CLI_FIXTURE),
+                    "languages": ["ts"],
+                },
+            },
+        }
+    )
+
+    assert response["error"]["code"] == -32000
+    assert "unsupported languages: ts; supported: md, py" == response["error"]["message"]
+
+
+def test_mcp_empty_language_filter_collects_nothing() -> None:
+    response = handle_request(
+        {
+            "jsonrpc": "2.0",
+            "id": 33,
+            "method": "tools/call",
+            "params": {
+                "name": "repogpt_emit_ast",
+                "arguments": {
+                    "repo_path": str(CLI_FIXTURE),
+                    "languages": [],
+                },
+            },
+        }
+    )
+
+    payload = _extract_content_text(response)
+    assert payload["exit_code"] == 0
+    assert payload["artifact"]["stats"]["total_files"] == 0
+    assert payload["artifact"]["records"] == []
 
 
 def test_mcp_emit_ast_supports_ndjson() -> None:

--- a/tests/unit/adapters/fs/test_collector.py
+++ b/tests/unit/adapters/fs/test_collector.py
@@ -23,7 +23,10 @@ def test_collect_ignores_git_files(tmp_path: Path) -> None:
 
 
 def test_collect_respects_repogptignore(tmp_path: Path) -> None:
-    (tmp_path / ".repogptignore").write_text("*.py\n__pycache__/\n", encoding="utf-8")
+    (tmp_path / ".repogptignore").write_text("*.py\n__pycache__/\ngenerated/\n", encoding="utf-8")
+    generated = tmp_path / "generated"
+    generated.mkdir()
+    (generated / "ignored.py").write_text("print('ignored')", encoding="utf-8")
     (tmp_path / "keep.py").write_text("print('ok')", encoding="utf-8")
     (tmp_path / "skip.py").write_text("print('no')", encoding="utf-8")
 
@@ -35,6 +38,7 @@ def test_collect_respects_repogptignore(tmp_path: Path) -> None:
         "keep.py",
         "skip.py",
     ]
+    assert "generated/ignored.py" not in {item.relative_path for item in skipped}
 
 
 def test_collect_includes_tests_when_requested(tmp_path: Path) -> None:
@@ -97,7 +101,7 @@ def test_collect_skipped_does_not_include_ignored_directories(tmp_path: Path) ->
         {"py"},
     )
 
-    assert all(item.abs_path.is_file() for item in skipped)
+    assert skipped == []
 
 
 def test_ignore_reason_reports_why_a_path_is_skipped(tmp_path: Path) -> None:
@@ -155,11 +159,11 @@ def test_collect_handles_invalid_repogptignore_pattern_without_failing(tmp_path:
 
     collector = DefaultCollector()
 
-    def raise_pattern_error(*args: object, **kwargs: object) -> pathspec.PathSpec:
+    def raise_pattern_error(*args: object, **kwargs: object) -> pathspec.GitIgnoreSpec:
         _ = args, kwargs
         raise ValueError("invalid pattern")
 
-    with patch.object(pathspec.PathSpec, "from_lines", raise_pattern_error):
+    with patch.object(pathspec.GitIgnoreSpec, "from_lines", raise_pattern_error):
         files, skipped = collector.collect(AnalysisRequest(repo_root=tmp_path), {"py"})
 
     assert {item.relative_path for item in files} == {"keep.py", "skip.py"}

--- a/tests/unit/utils/test_text_processing.py
+++ b/tests/unit/utils/test_text_processing.py
@@ -61,10 +61,10 @@ def test_docstring_examples() -> None:
     text = load_file("docstring_examples.py")
     comments = extract_comments(text, language="python")
     texts = [c["text"] for c in comments]
-    # Puede haber o no comentarios; adaptamos a la fixture real
+    # Keep this aligned with the real parser fixture.
     assert "Comentario entre docstring y código" in texts or texts == []
     todos, fixmes = extract_todos_fixmes(comments)
-    # Aquí depende de si hay TODO/FIXME en los comentarios del fichero
+    _ = todos, fixmes
 
 
 # ---------- BASIC MARKDOWN ----------
@@ -79,22 +79,18 @@ def test_comments_basic_md() -> None:
     assert comments == []
 
 
-# Añadir tests de regresión?
 def test_comments_edge_cases_py_unicode() -> None:
     text = load_file("edge_cases_comments.py")
     comments = extract_comments(text, language="python")
     texts = [c["text"] for c in comments]
     assert "Este es un comentario con acento: áéíóú" in texts
     assert any("😊" in t for t in texts)
-    assert not any(
-        t == "# Esto tampoco es comentario" for t in texts
-    )  # No debe incluir strings no comentario
+    assert not any(t == "# Esto tampoco es comentario" for t in texts)
     assert any("tarea pendiente λ" in t for t in texts)
     assert any("Comentario sin espacio tras hash" in t for t in texts)
     assert any("indentación" in t for t in texts)
     assert any("símbolos matemáticos" in t for t in texts)
     todos, fixmes = extract_todos_fixmes(comments)
-    # Dependiendo de tu extractor, podrías tener que adaptar estos asserts:
     assert any("λ" in t for t in todos)
     assert any("símbolos matemáticos" in f for f in fixmes)
 
@@ -113,11 +109,7 @@ def test_comments_edge_cases_md() -> None:
     assert any("ComentarioSinEspacios" in t for t in texts)
 
 
-# ── EDGE-3: líneas de comentarios HTML con bisect ────────────────────────────
-
-
 def test_markdown_comment_line_numbers_are_correct() -> None:
-    # Comentario en línea 1, 3, y multilínea que empieza en 5.
     content = "<!-- first -->\ntext\n<!-- second -->\nmore\n<!-- third\nend -->\n"
     comments = extract_comments(content, language="markdown")
     assert [c["line"] for c in comments] == [1, 3, 5]
@@ -135,7 +127,6 @@ def test_markdown_comment_after_several_newlines() -> None:
 
 
 def test_markdown_comment_line_numbers_match_old_behavior() -> None:
-    # Propiedad: bisect_left produce el mismo resultado que el count("\n") original.
     content = "line1\n<!-- a -->\nline3\n\n<!-- b -->\n<!-- c -->"
     comments = extract_comments(content, language="markdown")
     expected_lines = [

--- a/uv.lock
+++ b/uv.lock
@@ -3,6 +3,15 @@ revision = 3
 requires-python = ">=3.10"
 
 [[package]]
+name = "attrs"
+version = "26.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/9a/8e/82a0fe20a541c03148528be8cac2408564a6c9a0cc7e9171802bc1d26985/attrs-26.1.0.tar.gz", hash = "sha256:d03ceb89cb322a8fd706d4fb91940737b6642aa36998fe130a9bc96c985eff32", size = 952055, upload-time = "2026-03-19T14:22:25.026Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/64/b4/17d4b0b2a2dc85a6df63d1157e028ed19f90d4cd97c36717afef2bc2f395/attrs-26.1.0-py3-none-any.whl", hash = "sha256:c647aa4a12dfbad9333ca4e71fe62ddc36f4e63b2d260a37a8b83d2f043ac309", size = 67548, upload-time = "2026-03-19T14:22:23.645Z" },
+]
+
+[[package]]
 name = "cfgv"
 version = "3.5.0"
 source = { registry = "https://pypi.org/simple" }
@@ -179,6 +188,33 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/72/34/14ca021ce8e5dfedc35312d08ba8bf51fdd999c576889fc2c24cb97f4f10/iniconfig-2.3.0.tar.gz", hash = "sha256:c76315c77db068650d49c5b56314774a7804df16fee4402c1f19d6d15d8c4730", size = 20503, upload-time = "2025-10-18T21:55:43.219Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/cb/b1/3846dd7f199d53cb17f49cba7e651e9ce294d8497c8c150530ed11865bb8/iniconfig-2.3.0-py3-none-any.whl", hash = "sha256:f631c04d2c48c52b84d0d0549c99ff3859c98df65b3101406327ecc7d53fbf12", size = 7484, upload-time = "2025-10-18T21:55:41.639Z" },
+]
+
+[[package]]
+name = "jsonschema"
+version = "4.26.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "attrs" },
+    { name = "jsonschema-specifications" },
+    { name = "referencing" },
+    { name = "rpds-py" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b3/fc/e067678238fa451312d4c62bf6e6cf5ec56375422aee02f9cb5f909b3047/jsonschema-4.26.0.tar.gz", hash = "sha256:0c26707e2efad8aa1bfc5b7ce170f3fccc2e4918ff85989ba9ffa9facb2be326", size = 366583, upload-time = "2026-01-07T13:41:07.246Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/69/90/f63fb5873511e014207a475e2bb4e8b2e570d655b00ac19a9a0ca0a385ee/jsonschema-4.26.0-py3-none-any.whl", hash = "sha256:d489f15263b8d200f8387e64b4c3a75f06629559fb73deb8fdfb525f2dab50ce", size = 90630, upload-time = "2026-01-07T13:41:05.306Z" },
+]
+
+[[package]]
+name = "jsonschema-specifications"
+version = "2025.9.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "referencing" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/19/74/a633ee74eb36c44aa6d1095e7cc5569bebf04342ee146178e2d36600708b/jsonschema_specifications-2025.9.1.tar.gz", hash = "sha256:b540987f239e745613c7a9176f3edb72b832a4ac465cf02712288397832b5e8d", size = 32855, upload-time = "2025-09-08T01:34:59.186Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/41/45/1a4ed80516f02155c51f51e8cedb3c1902296743db0bbc66608a0db2814f/jsonschema_specifications-2025.9.1-py3-none-any.whl", hash = "sha256:98802fee3a11ee76ecaca44429fda8a41bff98b00a0f2838151b113f210cc6fe", size = 18437, upload-time = "2025-09-08T01:34:57.871Z" },
 ]
 
 [[package]]
@@ -487,6 +523,20 @@ wheels = [
 ]
 
 [[package]]
+name = "referencing"
+version = "0.37.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "attrs" },
+    { name = "rpds-py" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/22/f5/df4e9027acead3ecc63e50fe1e36aca1523e1719559c499951bb4b53188f/referencing-0.37.0.tar.gz", hash = "sha256:44aefc3142c5b842538163acb373e24cce6632bd54bdb01b21ad5863489f50d8", size = 78036, upload-time = "2025-10-13T15:30:48.871Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2c/58/ca301544e1fa93ed4f80d724bf5b194f6e4b945841c5bfd555878eea9fcb/referencing-0.37.0-py3-none-any.whl", hash = "sha256:381329a9f99628c9069361716891d34ad94af76e461dcb0335825aecc7692231", size = 26766, upload-time = "2025-10-13T15:30:47.625Z" },
+]
+
+[[package]]
 name = "repogpt"
 version = "0.8.3"
 source = { editable = "." }
@@ -498,6 +548,7 @@ dependencies = [
 [package.optional-dependencies]
 dev = [
     { name = "coverage" },
+    { name = "jsonschema" },
     { name = "mypy" },
     { name = "pre-commit" },
     { name = "pytest" },
@@ -507,6 +558,7 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "coverage", marker = "extra == 'dev'", specifier = ">=6.4" },
+    { name = "jsonschema", marker = "extra == 'dev'", specifier = ">=4.0" },
     { name = "mypy", marker = "extra == 'dev'", specifier = ">=1.0" },
     { name = "pathspec", specifier = ">=0.12.1" },
     { name = "pre-commit", marker = "extra == 'dev'", specifier = ">=2.20" },
@@ -515,6 +567,128 @@ requires-dist = [
     { name = "structlog", specifier = ">=24.1.0" },
 ]
 provides-extras = ["dev"]
+
+[[package]]
+name = "rpds-py"
+version = "0.30.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/20/af/3f2f423103f1113b36230496629986e0ef7e199d2aa8392452b484b38ced/rpds_py-0.30.0.tar.gz", hash = "sha256:dd8ff7cf90014af0c0f787eea34794ebf6415242ee1d6fa91eaba725cc441e84", size = 69469, upload-time = "2025-11-30T20:24:38.837Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/06/0c/0c411a0ec64ccb6d104dcabe0e713e05e153a9a2c3c2bd2b32ce412166fe/rpds_py-0.30.0-cp310-cp310-macosx_10_12_x86_64.whl", hash = "sha256:679ae98e00c0e8d68a7fda324e16b90fd5260945b45d3b824c892cec9eea3288", size = 370490, upload-time = "2025-11-30T20:21:33.256Z" },
+    { url = "https://files.pythonhosted.org/packages/19/6a/4ba3d0fb7297ebae71171822554abe48d7cab29c28b8f9f2c04b79988c05/rpds_py-0.30.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:4cc2206b76b4f576934f0ed374b10d7ca5f457858b157ca52064bdfc26b9fc00", size = 359751, upload-time = "2025-11-30T20:21:34.591Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/7c/e4933565ef7f7a0818985d87c15d9d273f1a649afa6a52ea35ad011195ea/rpds_py-0.30.0-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:389a2d49eded1896c3d48b0136ead37c48e221b391c052fba3f4055c367f60a6", size = 389696, upload-time = "2025-11-30T20:21:36.122Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/01/6271a2511ad0815f00f7ed4390cf2567bec1d4b1da39e2c27a41e6e3b4de/rpds_py-0.30.0-cp310-cp310-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:32c8528634e1bf7121f3de08fa85b138f4e0dc47657866630611b03967f041d7", size = 403136, upload-time = "2025-11-30T20:21:37.728Z" },
+    { url = "https://files.pythonhosted.org/packages/55/64/c857eb7cd7541e9b4eee9d49c196e833128a55b89a9850a9c9ac33ccf897/rpds_py-0.30.0-cp310-cp310-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:f207f69853edd6f6700b86efb84999651baf3789e78a466431df1331608e5324", size = 524699, upload-time = "2025-11-30T20:21:38.92Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/ed/94816543404078af9ab26159c44f9e98e20fe47e2126d5d32c9d9948d10a/rpds_py-0.30.0-cp310-cp310-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:67b02ec25ba7a9e8fa74c63b6ca44cf5707f2fbfadae3ee8e7494297d56aa9df", size = 412022, upload-time = "2025-11-30T20:21:40.407Z" },
+    { url = "https://files.pythonhosted.org/packages/61/b5/707f6cf0066a6412aacc11d17920ea2e19e5b2f04081c64526eb35b5c6e7/rpds_py-0.30.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:0c0e95f6819a19965ff420f65578bacb0b00f251fefe2c8b23347c37174271f3", size = 390522, upload-time = "2025-11-30T20:21:42.17Z" },
+    { url = "https://files.pythonhosted.org/packages/13/4e/57a85fda37a229ff4226f8cbcf09f2a455d1ed20e802ce5b2b4a7f5ed053/rpds_py-0.30.0-cp310-cp310-manylinux_2_31_riscv64.whl", hash = "sha256:a452763cc5198f2f98898eb98f7569649fe5da666c2dc6b5ddb10fde5a574221", size = 404579, upload-time = "2025-11-30T20:21:43.769Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/da/c9339293513ec680a721e0e16bf2bac3db6e5d7e922488de471308349bba/rpds_py-0.30.0-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:e0b65193a413ccc930671c55153a03ee57cecb49e6227204b04fae512eb657a7", size = 421305, upload-time = "2025-11-30T20:21:44.994Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/be/522cb84751114f4ad9d822ff5a1aa3c98006341895d5f084779b99596e5c/rpds_py-0.30.0-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:858738e9c32147f78b3ac24dc0edb6610000e56dc0f700fd5f651d0a0f0eb9ff", size = 572503, upload-time = "2025-11-30T20:21:46.91Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/9b/de879f7e7ceddc973ea6e4629e9b380213a6938a249e94b0cdbcc325bb66/rpds_py-0.30.0-cp310-cp310-musllinux_1_2_i686.whl", hash = "sha256:da279aa314f00acbb803da1e76fa18666778e8a8f83484fba94526da5de2cba7", size = 598322, upload-time = "2025-11-30T20:21:48.709Z" },
+    { url = "https://files.pythonhosted.org/packages/48/ac/f01fc22efec3f37d8a914fc1b2fb9bcafd56a299edbe96406f3053edea5a/rpds_py-0.30.0-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:7c64d38fb49b6cdeda16ab49e35fe0da2e1e9b34bc38bd78386530f218b37139", size = 560792, upload-time = "2025-11-30T20:21:50.024Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/da/4e2b19d0f131f35b6146425f846563d0ce036763e38913d917187307a671/rpds_py-0.30.0-cp310-cp310-win32.whl", hash = "sha256:6de2a32a1665b93233cde140ff8b3467bdb9e2af2b91079f0333a0974d12d464", size = 221901, upload-time = "2025-11-30T20:21:51.32Z" },
+    { url = "https://files.pythonhosted.org/packages/96/cb/156d7a5cf4f78a7cc571465d8aec7a3c447c94f6749c5123f08438bcf7bc/rpds_py-0.30.0-cp310-cp310-win_amd64.whl", hash = "sha256:1726859cd0de969f88dc8673bdd954185b9104e05806be64bcd87badbe313169", size = 235823, upload-time = "2025-11-30T20:21:52.505Z" },
+    { url = "https://files.pythonhosted.org/packages/4d/6e/f964e88b3d2abee2a82c1ac8366da848fce1c6d834dc2132c3fda3970290/rpds_py-0.30.0-cp311-cp311-macosx_10_12_x86_64.whl", hash = "sha256:a2bffea6a4ca9f01b3f8e548302470306689684e61602aa3d141e34da06cf425", size = 370157, upload-time = "2025-11-30T20:21:53.789Z" },
+    { url = "https://files.pythonhosted.org/packages/94/ba/24e5ebb7c1c82e74c4e4f33b2112a5573ddc703915b13a073737b59b86e0/rpds_py-0.30.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:dc4f992dfe1e2bc3ebc7444f6c7051b4bc13cd8e33e43511e8ffd13bf407010d", size = 359676, upload-time = "2025-11-30T20:21:55.475Z" },
+    { url = "https://files.pythonhosted.org/packages/84/86/04dbba1b087227747d64d80c3b74df946b986c57af0a9f0c98726d4d7a3b/rpds_py-0.30.0-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:422c3cb9856d80b09d30d2eb255d0754b23e090034e1deb4083f8004bd0761e4", size = 389938, upload-time = "2025-11-30T20:21:57.079Z" },
+    { url = "https://files.pythonhosted.org/packages/42/bb/1463f0b1722b7f45431bdd468301991d1328b16cffe0b1c2918eba2c4eee/rpds_py-0.30.0-cp311-cp311-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:07ae8a593e1c3c6b82ca3292efbe73c30b61332fd612e05abee07c79359f292f", size = 402932, upload-time = "2025-11-30T20:21:58.47Z" },
+    { url = "https://files.pythonhosted.org/packages/99/ee/2520700a5c1f2d76631f948b0736cdf9b0acb25abd0ca8e889b5c62ac2e3/rpds_py-0.30.0-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:12f90dd7557b6bd57f40abe7747e81e0c0b119bef015ea7726e69fe550e394a4", size = 525830, upload-time = "2025-11-30T20:21:59.699Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/ad/bd0331f740f5705cc555a5e17fdf334671262160270962e69a2bdef3bf76/rpds_py-0.30.0-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:99b47d6ad9a6da00bec6aabe5a6279ecd3c06a329d4aa4771034a21e335c3a97", size = 412033, upload-time = "2025-11-30T20:22:00.991Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/1e/372195d326549bb51f0ba0f2ecb9874579906b97e08880e7a65c3bef1a99/rpds_py-0.30.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:33f559f3104504506a44bb666b93a33f5d33133765b0c216a5bf2f1e1503af89", size = 390828, upload-time = "2025-11-30T20:22:02.723Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/2b/d88bb33294e3e0c76bc8f351a3721212713629ffca1700fa94979cb3eae8/rpds_py-0.30.0-cp311-cp311-manylinux_2_31_riscv64.whl", hash = "sha256:946fe926af6e44f3697abbc305ea168c2c31d3e3ef1058cf68f379bf0335a78d", size = 404683, upload-time = "2025-11-30T20:22:04.367Z" },
+    { url = "https://files.pythonhosted.org/packages/50/32/c759a8d42bcb5289c1fac697cd92f6fe01a018dd937e62ae77e0e7f15702/rpds_py-0.30.0-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:495aeca4b93d465efde585977365187149e75383ad2684f81519f504f5c13038", size = 421583, upload-time = "2025-11-30T20:22:05.814Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/81/e729761dbd55ddf5d84ec4ff1f47857f4374b0f19bdabfcf929164da3e24/rpds_py-0.30.0-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:d9a0ca5da0386dee0655b4ccdf46119df60e0f10da268d04fe7cc87886872ba7", size = 572496, upload-time = "2025-11-30T20:22:07.713Z" },
+    { url = "https://files.pythonhosted.org/packages/14/f6/69066a924c3557c9c30baa6ec3a0aa07526305684c6f86c696b08860726c/rpds_py-0.30.0-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:8d6d1cc13664ec13c1b84241204ff3b12f9bb82464b8ad6e7a5d3486975c2eed", size = 598669, upload-time = "2025-11-30T20:22:09.312Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/48/905896b1eb8a05630d20333d1d8ffd162394127b74ce0b0784ae04498d32/rpds_py-0.30.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:3896fa1be39912cf0757753826bc8bdc8ca331a28a7c4ae46b7a21280b06bb85", size = 561011, upload-time = "2025-11-30T20:22:11.309Z" },
+    { url = "https://files.pythonhosted.org/packages/22/16/cd3027c7e279d22e5eb431dd3c0fbc677bed58797fe7581e148f3f68818b/rpds_py-0.30.0-cp311-cp311-win32.whl", hash = "sha256:55f66022632205940f1827effeff17c4fa7ae1953d2b74a8581baaefb7d16f8c", size = 221406, upload-time = "2025-11-30T20:22:13.101Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/5b/e7b7aa136f28462b344e652ee010d4de26ee9fd16f1bfd5811f5153ccf89/rpds_py-0.30.0-cp311-cp311-win_amd64.whl", hash = "sha256:a51033ff701fca756439d641c0ad09a41d9242fa69121c7d8769604a0a629825", size = 236024, upload-time = "2025-11-30T20:22:14.853Z" },
+    { url = "https://files.pythonhosted.org/packages/14/a6/364bba985e4c13658edb156640608f2c9e1d3ea3c81b27aa9d889fff0e31/rpds_py-0.30.0-cp311-cp311-win_arm64.whl", hash = "sha256:47b0ef6231c58f506ef0b74d44e330405caa8428e770fec25329ed2cb971a229", size = 229069, upload-time = "2025-11-30T20:22:16.577Z" },
+    { url = "https://files.pythonhosted.org/packages/03/e7/98a2f4ac921d82f33e03f3835f5bf3a4a40aa1bfdc57975e74a97b2b4bdd/rpds_py-0.30.0-cp312-cp312-macosx_10_12_x86_64.whl", hash = "sha256:a161f20d9a43006833cd7068375a94d035714d73a172b681d8881820600abfad", size = 375086, upload-time = "2025-11-30T20:22:17.93Z" },
+    { url = "https://files.pythonhosted.org/packages/4d/a1/bca7fd3d452b272e13335db8d6b0b3ecde0f90ad6f16f3328c6fb150c889/rpds_py-0.30.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:6abc8880d9d036ecaafe709079969f56e876fcf107f7a8e9920ba6d5a3878d05", size = 359053, upload-time = "2025-11-30T20:22:19.297Z" },
+    { url = "https://files.pythonhosted.org/packages/65/1c/ae157e83a6357eceff62ba7e52113e3ec4834a84cfe07fa4b0757a7d105f/rpds_py-0.30.0-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ca28829ae5f5d569bb62a79512c842a03a12576375d5ece7d2cadf8abe96ec28", size = 390763, upload-time = "2025-11-30T20:22:21.661Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/36/eb2eb8515e2ad24c0bd43c3ee9cd74c33f7ca6430755ccdb240fd3144c44/rpds_py-0.30.0-cp312-cp312-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:a1010ed9524c73b94d15919ca4d41d8780980e1765babf85f9a2f90d247153dd", size = 408951, upload-time = "2025-11-30T20:22:23.408Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/65/ad8dc1784a331fabbd740ef6f71ce2198c7ed0890dab595adb9ea2d775a1/rpds_py-0.30.0-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:f8d1736cfb49381ba528cd5baa46f82fdc65c06e843dab24dd70b63d09121b3f", size = 514622, upload-time = "2025-11-30T20:22:25.16Z" },
+    { url = "https://files.pythonhosted.org/packages/63/8e/0cfa7ae158e15e143fe03993b5bcd743a59f541f5952e1546b1ac1b5fd45/rpds_py-0.30.0-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:d948b135c4693daff7bc2dcfc4ec57237a29bd37e60c2fabf5aff2bbacf3e2f1", size = 414492, upload-time = "2025-11-30T20:22:26.505Z" },
+    { url = "https://files.pythonhosted.org/packages/60/1b/6f8f29f3f995c7ffdde46a626ddccd7c63aefc0efae881dc13b6e5d5bb16/rpds_py-0.30.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:47f236970bccb2233267d89173d3ad2703cd36a0e2a6e92d0560d333871a3d23", size = 394080, upload-time = "2025-11-30T20:22:27.934Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/d5/a266341051a7a3ca2f4b750a3aa4abc986378431fc2da508c5034d081b70/rpds_py-0.30.0-cp312-cp312-manylinux_2_31_riscv64.whl", hash = "sha256:2e6ecb5a5bcacf59c3f912155044479af1d0b6681280048b338b28e364aca1f6", size = 408680, upload-time = "2025-11-30T20:22:29.341Z" },
+    { url = "https://files.pythonhosted.org/packages/10/3b/71b725851df9ab7a7a4e33cf36d241933da66040d195a84781f49c50490c/rpds_py-0.30.0-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:a8fa71a2e078c527c3e9dc9fc5a98c9db40bcc8a92b4e8858e36d329f8684b51", size = 423589, upload-time = "2025-11-30T20:22:31.469Z" },
+    { url = "https://files.pythonhosted.org/packages/00/2b/e59e58c544dc9bd8bd8384ecdb8ea91f6727f0e37a7131baeff8d6f51661/rpds_py-0.30.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:73c67f2db7bc334e518d097c6d1e6fed021bbc9b7d678d6cc433478365d1d5f5", size = 573289, upload-time = "2025-11-30T20:22:32.997Z" },
+    { url = "https://files.pythonhosted.org/packages/da/3e/a18e6f5b460893172a7d6a680e86d3b6bc87a54c1f0b03446a3c8c7b588f/rpds_py-0.30.0-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:5ba103fb455be00f3b1c2076c9d4264bfcb037c976167a6047ed82f23153f02e", size = 599737, upload-time = "2025-11-30T20:22:34.419Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/e2/714694e4b87b85a18e2c243614974413c60aa107fd815b8cbc42b873d1d7/rpds_py-0.30.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:7cee9c752c0364588353e627da8a7e808a66873672bcb5f52890c33fd965b394", size = 563120, upload-time = "2025-11-30T20:22:35.903Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/ab/d5d5e3bcedb0a77f4f613706b750e50a5a3ba1c15ccd3665ecc636c968fd/rpds_py-0.30.0-cp312-cp312-win32.whl", hash = "sha256:1ab5b83dbcf55acc8b08fc62b796ef672c457b17dbd7820a11d6c52c06839bdf", size = 223782, upload-time = "2025-11-30T20:22:37.271Z" },
+    { url = "https://files.pythonhosted.org/packages/39/3b/f786af9957306fdc38a74cef405b7b93180f481fb48453a114bb6465744a/rpds_py-0.30.0-cp312-cp312-win_amd64.whl", hash = "sha256:a090322ca841abd453d43456ac34db46e8b05fd9b3b4ac0c78bcde8b089f959b", size = 240463, upload-time = "2025-11-30T20:22:39.021Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/d2/b91dc748126c1559042cfe41990deb92c4ee3e2b415f6b5234969ffaf0cc/rpds_py-0.30.0-cp312-cp312-win_arm64.whl", hash = "sha256:669b1805bd639dd2989b281be2cfd951c6121b65e729d9b843e9639ef1fd555e", size = 230868, upload-time = "2025-11-30T20:22:40.493Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/dc/d61221eb88ff410de3c49143407f6f3147acf2538c86f2ab7ce65ae7d5f9/rpds_py-0.30.0-cp313-cp313-macosx_10_12_x86_64.whl", hash = "sha256:f83424d738204d9770830d35290ff3273fbb02b41f919870479fab14b9d303b2", size = 374887, upload-time = "2025-11-30T20:22:41.812Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/32/55fb50ae104061dbc564ef15cc43c013dc4a9f4527a1f4d99baddf56fe5f/rpds_py-0.30.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:e7536cd91353c5273434b4e003cbda89034d67e7710eab8761fd918ec6c69cf8", size = 358904, upload-time = "2025-11-30T20:22:43.479Z" },
+    { url = "https://files.pythonhosted.org/packages/58/70/faed8186300e3b9bdd138d0273109784eea2396c68458ed580f885dfe7ad/rpds_py-0.30.0-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:2771c6c15973347f50fece41fc447c054b7ac2ae0502388ce3b6738cd366e3d4", size = 389945, upload-time = "2025-11-30T20:22:44.819Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/a8/073cac3ed2c6387df38f71296d002ab43496a96b92c823e76f46b8af0543/rpds_py-0.30.0-cp313-cp313-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:0a59119fc6e3f460315fe9d08149f8102aa322299deaa5cab5b40092345c2136", size = 407783, upload-time = "2025-11-30T20:22:46.103Z" },
+    { url = "https://files.pythonhosted.org/packages/77/57/5999eb8c58671f1c11eba084115e77a8899d6e694d2a18f69f0ba471ec8b/rpds_py-0.30.0-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:76fec018282b4ead0364022e3c54b60bf368b9d926877957a8624b58419169b7", size = 515021, upload-time = "2025-11-30T20:22:47.458Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/af/5ab4833eadc36c0a8ed2bc5c0de0493c04f6c06de223170bd0798ff98ced/rpds_py-0.30.0-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:692bef75a5525db97318e8cd061542b5a79812d711ea03dbc1f6f8dbb0c5f0d2", size = 414589, upload-time = "2025-11-30T20:22:48.872Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/de/f7192e12b21b9e9a68a6d0f249b4af3fdcdff8418be0767a627564afa1f1/rpds_py-0.30.0-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:9027da1ce107104c50c81383cae773ef5c24d296dd11c99e2629dbd7967a20c6", size = 394025, upload-time = "2025-11-30T20:22:50.196Z" },
+    { url = "https://files.pythonhosted.org/packages/91/c4/fc70cd0249496493500e7cc2de87504f5aa6509de1e88623431fec76d4b6/rpds_py-0.30.0-cp313-cp313-manylinux_2_31_riscv64.whl", hash = "sha256:9cf69cdda1f5968a30a359aba2f7f9aa648a9ce4b580d6826437f2b291cfc86e", size = 408895, upload-time = "2025-11-30T20:22:51.87Z" },
+    { url = "https://files.pythonhosted.org/packages/58/95/d9275b05ab96556fefff73a385813eb66032e4c99f411d0795372d9abcea/rpds_py-0.30.0-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:a4796a717bf12b9da9d3ad002519a86063dcac8988b030e405704ef7d74d2d9d", size = 422799, upload-time = "2025-11-30T20:22:53.341Z" },
+    { url = "https://files.pythonhosted.org/packages/06/c1/3088fc04b6624eb12a57eb814f0d4997a44b0d208d6cace713033ff1a6ba/rpds_py-0.30.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:5d4c2aa7c50ad4728a094ebd5eb46c452e9cb7edbfdb18f9e1221f597a73e1e7", size = 572731, upload-time = "2025-11-30T20:22:54.778Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/42/c612a833183b39774e8ac8fecae81263a68b9583ee343db33ab571a7ce55/rpds_py-0.30.0-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:ba81a9203d07805435eb06f536d95a266c21e5b2dfbf6517748ca40c98d19e31", size = 599027, upload-time = "2025-11-30T20:22:56.212Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/60/525a50f45b01d70005403ae0e25f43c0384369ad24ffe46e8d9068b50086/rpds_py-0.30.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:945dccface01af02675628334f7cf49c2af4c1c904748efc5cf7bbdf0b579f95", size = 563020, upload-time = "2025-11-30T20:22:58.2Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/5d/47c4655e9bcd5ca907148535c10e7d489044243cc9941c16ed7cd53be91d/rpds_py-0.30.0-cp313-cp313-win32.whl", hash = "sha256:b40fb160a2db369a194cb27943582b38f79fc4887291417685f3ad693c5a1d5d", size = 223139, upload-time = "2025-11-30T20:23:00.209Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/e1/485132437d20aa4d3e1d8b3fb5a5e65aa8139f1e097080c2a8443201742c/rpds_py-0.30.0-cp313-cp313-win_amd64.whl", hash = "sha256:806f36b1b605e2d6a72716f321f20036b9489d29c51c91f4dd29a3e3afb73b15", size = 240224, upload-time = "2025-11-30T20:23:02.008Z" },
+    { url = "https://files.pythonhosted.org/packages/24/95/ffd128ed1146a153d928617b0ef673960130be0009c77d8fbf0abe306713/rpds_py-0.30.0-cp313-cp313-win_arm64.whl", hash = "sha256:d96c2086587c7c30d44f31f42eae4eac89b60dabbac18c7669be3700f13c3ce1", size = 230645, upload-time = "2025-11-30T20:23:03.43Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/1b/b10de890a0def2a319a2626334a7f0ae388215eb60914dbac8a3bae54435/rpds_py-0.30.0-cp313-cp313t-macosx_10_12_x86_64.whl", hash = "sha256:eb0b93f2e5c2189ee831ee43f156ed34e2a89a78a66b98cadad955972548be5a", size = 364443, upload-time = "2025-11-30T20:23:04.878Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/bf/27e39f5971dc4f305a4fb9c672ca06f290f7c4e261c568f3dea16a410d47/rpds_py-0.30.0-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:922e10f31f303c7c920da8981051ff6d8c1a56207dbdf330d9047f6d30b70e5e", size = 353375, upload-time = "2025-11-30T20:23:06.342Z" },
+    { url = "https://files.pythonhosted.org/packages/40/58/442ada3bba6e8e6615fc00483135c14a7538d2ffac30e2d933ccf6852232/rpds_py-0.30.0-cp313-cp313t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:cdc62c8286ba9bf7f47befdcea13ea0e26bf294bda99758fd90535cbaf408000", size = 383850, upload-time = "2025-11-30T20:23:07.825Z" },
+    { url = "https://files.pythonhosted.org/packages/14/14/f59b0127409a33c6ef6f5c1ebd5ad8e32d7861c9c7adfa9a624fc3889f6c/rpds_py-0.30.0-cp313-cp313t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:47f9a91efc418b54fb8190a6b4aa7813a23fb79c51f4bb84e418f5476c38b8db", size = 392812, upload-time = "2025-11-30T20:23:09.228Z" },
+    { url = "https://files.pythonhosted.org/packages/b3/66/e0be3e162ac299b3a22527e8913767d869e6cc75c46bd844aa43fb81ab62/rpds_py-0.30.0-cp313-cp313t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:1f3587eb9b17f3789ad50824084fa6f81921bbf9a795826570bda82cb3ed91f2", size = 517841, upload-time = "2025-11-30T20:23:11.186Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/55/fa3b9cf31d0c963ecf1ba777f7cf4b2a2c976795ac430d24a1f43d25a6ba/rpds_py-0.30.0-cp313-cp313t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:39c02563fc592411c2c61d26b6c5fe1e51eaa44a75aa2c8735ca88b0d9599daa", size = 408149, upload-time = "2025-11-30T20:23:12.864Z" },
+    { url = "https://files.pythonhosted.org/packages/60/ca/780cf3b1a32b18c0f05c441958d3758f02544f1d613abf9488cd78876378/rpds_py-0.30.0-cp313-cp313t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:51a1234d8febafdfd33a42d97da7a43f5dcb120c1060e352a3fbc0c6d36e2083", size = 383843, upload-time = "2025-11-30T20:23:14.638Z" },
+    { url = "https://files.pythonhosted.org/packages/82/86/d5f2e04f2aa6247c613da0c1dd87fcd08fa17107e858193566048a1e2f0a/rpds_py-0.30.0-cp313-cp313t-manylinux_2_31_riscv64.whl", hash = "sha256:eb2c4071ab598733724c08221091e8d80e89064cd472819285a9ab0f24bcedb9", size = 396507, upload-time = "2025-11-30T20:23:16.105Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/9a/453255d2f769fe44e07ea9785c8347edaf867f7026872e76c1ad9f7bed92/rpds_py-0.30.0-cp313-cp313t-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:6bdfdb946967d816e6adf9a3d8201bfad269c67efe6cefd7093ef959683c8de0", size = 414949, upload-time = "2025-11-30T20:23:17.539Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/31/622a86cdc0c45d6df0e9ccb6becdba5074735e7033c20e401a6d9d0e2ca0/rpds_py-0.30.0-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:c77afbd5f5250bf27bf516c7c4a016813eb2d3e116139aed0096940c5982da94", size = 565790, upload-time = "2025-11-30T20:23:19.029Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/5d/15bbf0fb4a3f58a3b1c67855ec1efcc4ceaef4e86644665fff03e1b66d8d/rpds_py-0.30.0-cp313-cp313t-musllinux_1_2_i686.whl", hash = "sha256:61046904275472a76c8c90c9ccee9013d70a6d0f73eecefd38c1ae7c39045a08", size = 590217, upload-time = "2025-11-30T20:23:20.885Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/61/21b8c41f68e60c8cc3b2e25644f0e3681926020f11d06ab0b78e3c6bbff1/rpds_py-0.30.0-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:4c5f36a861bc4b7da6516dbdf302c55313afa09b81931e8280361a4f6c9a2d27", size = 555806, upload-time = "2025-11-30T20:23:22.488Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/39/7e067bb06c31de48de3eb200f9fc7c58982a4d3db44b07e73963e10d3be9/rpds_py-0.30.0-cp313-cp313t-win32.whl", hash = "sha256:3d4a69de7a3e50ffc214ae16d79d8fbb0922972da0356dcf4d0fdca2878559c6", size = 211341, upload-time = "2025-11-30T20:23:24.449Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/4d/222ef0b46443cf4cf46764d9c630f3fe4abaa7245be9417e56e9f52b8f65/rpds_py-0.30.0-cp313-cp313t-win_amd64.whl", hash = "sha256:f14fc5df50a716f7ece6a80b6c78bb35ea2ca47c499e422aa4463455dd96d56d", size = 225768, upload-time = "2025-11-30T20:23:25.908Z" },
+    { url = "https://files.pythonhosted.org/packages/86/81/dad16382ebbd3d0e0328776d8fd7ca94220e4fa0798d1dc5e7da48cb3201/rpds_py-0.30.0-cp314-cp314-macosx_10_12_x86_64.whl", hash = "sha256:68f19c879420aa08f61203801423f6cd5ac5f0ac4ac82a2368a9fcd6a9a075e0", size = 362099, upload-time = "2025-11-30T20:23:27.316Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/60/19f7884db5d5603edf3c6bce35408f45ad3e97e10007df0e17dd57af18f8/rpds_py-0.30.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:ec7c4490c672c1a0389d319b3a9cfcd098dcdc4783991553c332a15acf7249be", size = 353192, upload-time = "2025-11-30T20:23:29.151Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/c4/76eb0e1e72d1a9c4703c69607cec123c29028bff28ce41588792417098ac/rpds_py-0.30.0-cp314-cp314-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:f251c812357a3fed308d684a5079ddfb9d933860fc6de89f2b7ab00da481e65f", size = 384080, upload-time = "2025-11-30T20:23:30.785Z" },
+    { url = "https://files.pythonhosted.org/packages/72/87/87ea665e92f3298d1b26d78814721dc39ed8d2c74b86e83348d6b48a6f31/rpds_py-0.30.0-cp314-cp314-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:ac98b175585ecf4c0348fd7b29c3864bda53b805c773cbf7bfdaffc8070c976f", size = 394841, upload-time = "2025-11-30T20:23:32.209Z" },
+    { url = "https://files.pythonhosted.org/packages/77/ad/7783a89ca0587c15dcbf139b4a8364a872a25f861bdb88ed99f9b0dec985/rpds_py-0.30.0-cp314-cp314-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:3e62880792319dbeb7eb866547f2e35973289e7d5696c6e295476448f5b63c87", size = 516670, upload-time = "2025-11-30T20:23:33.742Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/3c/2882bdac942bd2172f3da574eab16f309ae10a3925644e969536553cb4ee/rpds_py-0.30.0-cp314-cp314-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:4e7fc54e0900ab35d041b0601431b0a0eb495f0851a0639b6ef90f7741b39a18", size = 408005, upload-time = "2025-11-30T20:23:35.253Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/81/9a91c0111ce1758c92516a3e44776920b579d9a7c09b2b06b642d4de3f0f/rpds_py-0.30.0-cp314-cp314-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:47e77dc9822d3ad616c3d5759ea5631a75e5809d5a28707744ef79d7a1bcfcad", size = 382112, upload-time = "2025-11-30T20:23:36.842Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/8e/1da49d4a107027e5fbc64daeab96a0706361a2918da10cb41769244b805d/rpds_py-0.30.0-cp314-cp314-manylinux_2_31_riscv64.whl", hash = "sha256:b4dc1a6ff022ff85ecafef7979a2c6eb423430e05f1165d6688234e62ba99a07", size = 399049, upload-time = "2025-11-30T20:23:38.343Z" },
+    { url = "https://files.pythonhosted.org/packages/df/5a/7ee239b1aa48a127570ec03becbb29c9d5a9eb092febbd1699d567cae859/rpds_py-0.30.0-cp314-cp314-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:4559c972db3a360808309e06a74628b95eaccbf961c335c8fe0d590cf587456f", size = 415661, upload-time = "2025-11-30T20:23:40.263Z" },
+    { url = "https://files.pythonhosted.org/packages/70/ea/caa143cf6b772f823bc7929a45da1fa83569ee49b11d18d0ada7f5ee6fd6/rpds_py-0.30.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:0ed177ed9bded28f8deb6ab40c183cd1192aa0de40c12f38be4d59cd33cb5c65", size = 565606, upload-time = "2025-11-30T20:23:42.186Z" },
+    { url = "https://files.pythonhosted.org/packages/64/91/ac20ba2d69303f961ad8cf55bf7dbdb4763f627291ba3d0d7d67333cced9/rpds_py-0.30.0-cp314-cp314-musllinux_1_2_i686.whl", hash = "sha256:ad1fa8db769b76ea911cb4e10f049d80bf518c104f15b3edb2371cc65375c46f", size = 591126, upload-time = "2025-11-30T20:23:44.086Z" },
+    { url = "https://files.pythonhosted.org/packages/21/20/7ff5f3c8b00c8a95f75985128c26ba44503fb35b8e0259d812766ea966c7/rpds_py-0.30.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:46e83c697b1f1c72b50e5ee5adb4353eef7406fb3f2043d64c33f20ad1c2fc53", size = 553371, upload-time = "2025-11-30T20:23:46.004Z" },
+    { url = "https://files.pythonhosted.org/packages/72/c7/81dadd7b27c8ee391c132a6b192111ca58d866577ce2d9b0ca157552cce0/rpds_py-0.30.0-cp314-cp314-win32.whl", hash = "sha256:ee454b2a007d57363c2dfd5b6ca4a5d7e2c518938f8ed3b706e37e5d470801ed", size = 215298, upload-time = "2025-11-30T20:23:47.696Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/d2/1aaac33287e8cfb07aab2e6b8ac1deca62f6f65411344f1433c55e6f3eb8/rpds_py-0.30.0-cp314-cp314-win_amd64.whl", hash = "sha256:95f0802447ac2d10bcc69f6dc28fe95fdf17940367b21d34e34c737870758950", size = 228604, upload-time = "2025-11-30T20:23:49.501Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/95/ab005315818cc519ad074cb7784dae60d939163108bd2b394e60dc7b5461/rpds_py-0.30.0-cp314-cp314-win_arm64.whl", hash = "sha256:613aa4771c99f03346e54c3f038e4cc574ac09a3ddfb0e8878487335e96dead6", size = 222391, upload-time = "2025-11-30T20:23:50.96Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/68/154fe0194d83b973cdedcdcc88947a2752411165930182ae41d983dcefa6/rpds_py-0.30.0-cp314-cp314t-macosx_10_12_x86_64.whl", hash = "sha256:7e6ecfcb62edfd632e56983964e6884851786443739dbfe3582947e87274f7cb", size = 364868, upload-time = "2025-11-30T20:23:52.494Z" },
+    { url = "https://files.pythonhosted.org/packages/83/69/8bbc8b07ec854d92a8b75668c24d2abcb1719ebf890f5604c61c9369a16f/rpds_py-0.30.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:a1d0bc22a7cdc173fedebb73ef81e07faef93692b8c1ad3733b67e31e1b6e1b8", size = 353747, upload-time = "2025-11-30T20:23:54.036Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/00/ba2e50183dbd9abcce9497fa5149c62b4ff3e22d338a30d690f9af970561/rpds_py-0.30.0-cp314-cp314t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:0d08f00679177226c4cb8c5265012eea897c8ca3b93f429e546600c971bcbae7", size = 383795, upload-time = "2025-11-30T20:23:55.556Z" },
+    { url = "https://files.pythonhosted.org/packages/05/6f/86f0272b84926bcb0e4c972262f54223e8ecc556b3224d281e6598fc9268/rpds_py-0.30.0-cp314-cp314t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:5965af57d5848192c13534f90f9dd16464f3c37aaf166cc1da1cae1fd5a34898", size = 393330, upload-time = "2025-11-30T20:23:57.033Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/e9/0e02bb2e6dc63d212641da45df2b0bf29699d01715913e0d0f017ee29438/rpds_py-0.30.0-cp314-cp314t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:9a4e86e34e9ab6b667c27f3211ca48f73dba7cd3d90f8d5b11be56e5dbc3fb4e", size = 518194, upload-time = "2025-11-30T20:23:58.637Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/ca/be7bca14cf21513bdf9c0606aba17d1f389ea2b6987035eb4f62bd923f25/rpds_py-0.30.0-cp314-cp314t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:e5d3e6b26f2c785d65cc25ef1e5267ccbe1b069c5c21b8cc724efee290554419", size = 408340, upload-time = "2025-11-30T20:24:00.2Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/c7/736e00ebf39ed81d75544c0da6ef7b0998f8201b369acf842f9a90dc8fce/rpds_py-0.30.0-cp314-cp314t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:626a7433c34566535b6e56a1b39a7b17ba961e97ce3b80ec62e6f1312c025551", size = 383765, upload-time = "2025-11-30T20:24:01.759Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/3f/da50dfde9956aaf365c4adc9533b100008ed31aea635f2b8d7b627e25b49/rpds_py-0.30.0-cp314-cp314t-manylinux_2_31_riscv64.whl", hash = "sha256:acd7eb3f4471577b9b5a41baf02a978e8bdeb08b4b355273994f8b87032000a8", size = 396834, upload-time = "2025-11-30T20:24:03.687Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/00/34bcc2565b6020eab2623349efbdec810676ad571995911f1abdae62a3a0/rpds_py-0.30.0-cp314-cp314t-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:fe5fa731a1fa8a0a56b0977413f8cacac1768dad38d16b3a296712709476fbd5", size = 415470, upload-time = "2025-11-30T20:24:05.232Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/28/882e72b5b3e6f718d5453bd4d0d9cf8df36fddeb4ddbbab17869d5868616/rpds_py-0.30.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:74a3243a411126362712ee1524dfc90c650a503502f135d54d1b352bd01f2404", size = 565630, upload-time = "2025-11-30T20:24:06.878Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/97/04a65539c17692de5b85c6e293520fd01317fd878ea1995f0367d4532fb1/rpds_py-0.30.0-cp314-cp314t-musllinux_1_2_i686.whl", hash = "sha256:3e8eeb0544f2eb0d2581774be4c3410356eba189529a6b3e36bbbf9696175856", size = 591148, upload-time = "2025-11-30T20:24:08.445Z" },
+    { url = "https://files.pythonhosted.org/packages/85/70/92482ccffb96f5441aab93e26c4d66489eb599efdcf96fad90c14bbfb976/rpds_py-0.30.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:dbd936cde57abfee19ab3213cf9c26be06d60750e60a8e4dd85d1ab12c8b1f40", size = 556030, upload-time = "2025-11-30T20:24:10.956Z" },
+    { url = "https://files.pythonhosted.org/packages/20/53/7c7e784abfa500a2b6b583b147ee4bb5a2b3747a9166bab52fec4b5b5e7d/rpds_py-0.30.0-cp314-cp314t-win32.whl", hash = "sha256:dc824125c72246d924f7f796b4f63c1e9dc810c7d9e2355864b3c3a73d59ade0", size = 211570, upload-time = "2025-11-30T20:24:12.735Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/02/fa464cdfbe6b26e0600b62c528b72d8608f5cc49f96b8d6e38c95d60c676/rpds_py-0.30.0-cp314-cp314t-win_amd64.whl", hash = "sha256:27f4b0e92de5bfbc6f86e43959e6edd1425c33b5e69aab0984a72047f2bcf1e3", size = 226532, upload-time = "2025-11-30T20:24:14.634Z" },
+    { url = "https://files.pythonhosted.org/packages/69/71/3f34339ee70521864411f8b6992e7ab13ac30d8e4e3309e07c7361767d91/rpds_py-0.30.0-pp311-pypy311_pp73-macosx_10_12_x86_64.whl", hash = "sha256:c2262bdba0ad4fc6fb5545660673925c2d2a5d9e2e0fb603aad545427be0fc58", size = 372292, upload-time = "2025-11-30T20:24:16.537Z" },
+    { url = "https://files.pythonhosted.org/packages/57/09/f183df9b8f2d66720d2ef71075c59f7e1b336bec7ee4c48f0a2b06857653/rpds_py-0.30.0-pp311-pypy311_pp73-macosx_11_0_arm64.whl", hash = "sha256:ee6af14263f25eedc3bb918a3c04245106a42dfd4f5c2285ea6f997b1fc3f89a", size = 362128, upload-time = "2025-11-30T20:24:18.086Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/68/5c2594e937253457342e078f0cc1ded3dd7b2ad59afdbf2d354869110a02/rpds_py-0.30.0-pp311-pypy311_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:3adbb8179ce342d235c31ab8ec511e66c73faa27a47e076ccc92421add53e2bb", size = 391542, upload-time = "2025-11-30T20:24:20.092Z" },
+    { url = "https://files.pythonhosted.org/packages/49/5c/31ef1afd70b4b4fbdb2800249f34c57c64beb687495b10aec0365f53dfc4/rpds_py-0.30.0-pp311-pypy311_pp73-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:250fa00e9543ac9b97ac258bd37367ff5256666122c2d0f2bc97577c60a1818c", size = 404004, upload-time = "2025-11-30T20:24:22.231Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/63/0cfbea38d05756f3440ce6534d51a491d26176ac045e2707adc99bb6e60a/rpds_py-0.30.0-pp311-pypy311_pp73-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:9854cf4f488b3d57b9aaeb105f06d78e5529d3145b1e4a41750167e8c213c6d3", size = 527063, upload-time = "2025-11-30T20:24:24.302Z" },
+    { url = "https://files.pythonhosted.org/packages/42/e6/01e1f72a2456678b0f618fc9a1a13f882061690893c192fcad9f2926553a/rpds_py-0.30.0-pp311-pypy311_pp73-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:993914b8e560023bc0a8bf742c5f303551992dcb85e247b1e5c7f4a7d145bda5", size = 413099, upload-time = "2025-11-30T20:24:25.916Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/25/8df56677f209003dcbb180765520c544525e3ef21ea72279c98b9aa7c7fb/rpds_py-0.30.0-pp311-pypy311_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:58edca431fb9b29950807e301826586e5bbf24163677732429770a697ffe6738", size = 392177, upload-time = "2025-11-30T20:24:27.834Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/b4/0a771378c5f16f8115f796d1f437950158679bcd2a7c68cf251cfb00ed5b/rpds_py-0.30.0-pp311-pypy311_pp73-manylinux_2_31_riscv64.whl", hash = "sha256:dea5b552272a944763b34394d04577cf0f9bd013207bc32323b5a89a53cf9c2f", size = 406015, upload-time = "2025-11-30T20:24:29.457Z" },
+    { url = "https://files.pythonhosted.org/packages/36/d8/456dbba0af75049dc6f63ff295a2f92766b9d521fa00de67a2bd6427d57a/rpds_py-0.30.0-pp311-pypy311_pp73-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:ba3af48635eb83d03f6c9735dfb21785303e73d22ad03d489e88adae6eab8877", size = 423736, upload-time = "2025-11-30T20:24:31.22Z" },
+    { url = "https://files.pythonhosted.org/packages/13/64/b4d76f227d5c45a7e0b796c674fd81b0a6c4fbd48dc29271857d8219571c/rpds_py-0.30.0-pp311-pypy311_pp73-musllinux_1_2_aarch64.whl", hash = "sha256:dff13836529b921e22f15cb099751209a60009731a68519630a24d61f0b1b30a", size = 573981, upload-time = "2025-11-30T20:24:32.934Z" },
+    { url = "https://files.pythonhosted.org/packages/20/91/092bacadeda3edf92bf743cc96a7be133e13a39cdbfd7b5082e7ab638406/rpds_py-0.30.0-pp311-pypy311_pp73-musllinux_1_2_i686.whl", hash = "sha256:1b151685b23929ab7beec71080a8889d4d6d9fa9a983d213f07121205d48e2c4", size = 599782, upload-time = "2025-11-30T20:24:35.169Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/b7/b95708304cd49b7b6f82fdd039f1748b66ec2b21d6a45180910802f1abf1/rpds_py-0.30.0-pp311-pypy311_pp73-musllinux_1_2_x86_64.whl", hash = "sha256:ac37f9f516c51e5753f27dfdef11a88330f04de2d564be3991384b2f3535d02e", size = 562191, upload-time = "2025-11-30T20:24:36.853Z" },
+]
 
 [[package]]
 name = "ruff"


### PR DESCRIPTION
## Summary

This PR hardens RepoGPT’s public contract and runtime consistency:

- shares language validation between CLI and MCP
- prunes ignored directories during collection for better large-repo behavior
- adds JSON Schema validation for AST v1 and code-units v4 golden artifacts
- removes duplicated package version metadata
- cleans stale/internal comments and updates docs

## Behavior Changes

- MCP now normalizes language filters like the CLI and rejects unsupported languages instead of silently collecting nothing.
- Ignored directories are pruned before descent and no longer expanded into per-file skipped entries.
- `.repogptignore` uses `pathspec.GitIgnoreSpec`, removing pathspec deprecation warnings.

## Validation

- `env UV_CACHE_DIR=.uv_cache uv run ruff check .`
- `env UV_CACHE_DIR=.uv_cache uv run mypy src tests`
- `env UV_CACHE_DIR=.uv_cache uv run python -m pytest -q`

Result: `117 passed`